### PR TITLE
Change order of gcc flags so we can build with newer versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OBJS = \
 	aggregator.o
 
 relay: $(OBJS)
-	$(CC) -o $@ $(LDFLAGS) $(LIBS) $^
+	$(CC) -o $@ $(LDFLAGS) $^ $(LIBS)
 
 clean:
 	rm -f *.o relay

--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@ carbon-c-relay
 
 Carbon-like graphite line mode relay.
 
-This project aims to be a replacement of the original Carbon relay
-[#carbon]_.
-
-.. [#carbon] http://graphite.readthedocs.org/en/1.0/carbon-daemons.html#carbon-relay-py
+This project aims to be a replacement of the original [Carbon relay](http://graphite.readthedocs.org/en/1.0/carbon-daemons.html#carbon-relay-py)
 
 The main reason to build a replacement is performance and
 configurability.  Carbon is single threaded, and sending metrics to
@@ -15,11 +12,8 @@ project provides a multithreaded relay which can address multiple
 targets and clusters for each and every metric based on pattern matches.
 
 There are a couple more replacement projects out there we know of, which
-are carbon-relay-ng [#carbon-relay-ng]_ and graphite-relay
-[#graphite-relay]_.
-
-.. [#carbon-relay-ng] https://github.com/rcrowley/carbon-relay-ng
-.. [#graphite-relay] https://github.com/markchadwick/graphite-relay
+are [carbon-relay-ng](https://github.com/rcrowley/carbon-relay-ng) and [graphite-relay](https://github.com/markchadwick/graphite-relay
+)
 
 Compared to carbon-relay-ng, this project does provide carbon's
 consistent-hash routing.  graphite-relay, which does this, however


### PR DESCRIPTION
On newer versions of gcc, if the ordering of the gcc flags isn't correct, you get compilation errors such as:

```
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o relay.o relay.c
relay.c: In function ‘main’:
relay.c:108:6: warning: variable ‘bflag’ set but not used [-Wunused-but-set-variable]
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o carbon-hash.o carbon-hash.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o receptor.o receptor.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o dispatcher.o dispatcher.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o router.o router.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o queue.o queue.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o server.o server.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o collector.o collector.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o aggregator.o aggregator.c
cc -o relay  `pkg-config openssl --libs` -pthread -lssl -lcrypto relay.o carbon-hash.o receptor.o dispatcher.o router.o queue.o server.o collector.o aggregator.o
carbon-hash.o: In function `carbon_hashpos':
carbon-hash.c:(.text+0x37): undefined reference to `MD5'
collect2: ld returned 1 exit status
make: *** [relay] Error 1
```

Switching the parameters around results in a successful compile:

```
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o relay.o relay.c
relay.c: In function ‘main’:
relay.c:108:6: warning: variable ‘bflag’ set but not used [-Wunused-but-set-variable]
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o carbon-hash.o carbon-hash.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o receptor.o receptor.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o dispatcher.o dispatcher.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o router.o router.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o queue.o queue.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o server.o server.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o collector.o collector.c
cc -O2 -Wall -DGIT_VERSION=\"2014-02-06\" `pkg-config openssl --cflags` -pthread   -c -o aggregator.o aggregator.c
cc -o carbon-relay  relay.o carbon-hash.o receptor.o dispatcher.o router.o queue.o server.o collector.o aggregator.o `pkg-config openssl --libs` -pthread

```
