### PR TITLE
Accept tabs as separator characters

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -291,9 +291,9 @@ dispatch_connection(connection *conn, dispatcher *self)
 			{
 				/* copy char */
 				*q++ = *p;
-			} else if (*p == ' ' || *p == '.') {
+			} else if (*p == ' ' || *p == '.' || *p == '\t') {
 				/* separator */
-				if (*p == ' ' && firstspace == NULL) {
+			  if ((*p == ' ' || *p == '\t') && firstspace == NULL) {
 					if (q == conn->metric)
 						continue;
 					if (*(q - 1) == '.')


### PR DESCRIPTION
Graphite accepts both spaces and tabs as separators in line metric format but carbon-c-relay only accepts spaces. This causes relay to drop line metric messages that would otherwise be accepted by graphite and are sent by some clients. 

Sensu for example uses tabs when sending data to graphite and these metrics are not accepted by carbon-c-relay but are accepted by carbon caches and the built in carbon relay.

Graphite will actually accept multiples of spaces and or tabs as separators - have not seen clients that use multiple whitespace in that way though.

Thanks for the carbon-c-relay release, very useful and certainly several orders of magnitude faster and more stable than the built in relay.

This pull request fixes #7 
