### PR TITLE
Fix value tampering

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -342,8 +342,12 @@ dispatch_connection(connection *conn, dispatcher *self)
 					break;
 			} else {
                 if (firstspace == NULL) {
-                    /* something barf, replace by underscore if it's in the metric-path */
+                    /* something barf, replace by underscore if it's in the metric_path */
                     *q++ = '_';
+                }
+                else if (*p == '+') {
+                    /* we're after the metric_path, copy if allowed char */
+                    *q++ = *p;
                 }
 			}
 		}


### PR DESCRIPTION
Collectd gives values in exponential format when polling 64-bit snmp counters (and possibly other sources as well?);

datacenter.g30.collectd.sample_host.snmp.if_octets-Port-channel113.tx 1.0665e+06 1411043207

Prior to this change the '+' was replaced by a '_' which made carbon-cache discard the value.
