### PR TITLE
Create additional directories in $RPM_BUILD_ROOT

### DIFF
--- a/contrib/relay.spec
+++ b/contrib/relay.spec
@@ -29,6 +29,9 @@ mkdir -vp $RPM_BUILD_ROOT/var/log/carbon/
 mkdir -vp $RPM_BUILD_ROOT/etc/monit.d/
 mkdir -vp $RPM_BUILD_ROOT/var/run/carbon
 mkdir -vp $RPM_BUILD_ROOT/var/lib/carbon
+mkdir -vp $RPM_BUILD_ROOT/usr/bin
+mkdir -vp $RPM_BUILD_ROOT/etc/init.d
+mkdir -vp $RPM_BUILD_ROOT/etc/sysconfig
 install -m 755 relay $RPM_BUILD_ROOT/usr/bin/relay
 install -m 644 contrib/relay.conf $RPM_BUILD_ROOT/etc/relay.conf
 install -m 755 contrib/relay.init $RPM_BUILD_ROOT/etc/init.d/relay


### PR DESCRIPTION
The existing spec file does not create the /usr/bin, /etc/init.d/or /etc/sysconfig directories in the $RPM_BUILD_ROOT, which causes rpmbuild to error out with errors such as this:

install: cannot create regular file `/root/rpmbuild/BUILDROOT/relay-0.32-1.el6.x86_64/etc/init.d/relay': No such file or directory