### PR TITLE
Specific -std=gnu89 for old inline semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-CFLAGS ?= -O2 -Wall
+CFLAGS ?= -O2 -Wall -std=gnu89
 
 GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always || date +%F)
 GVCFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"


### PR DESCRIPTION
This is required to fix compilation with Xcode 5.1.  See:
http://clang.llvm.org/compatibility.html#inline