### PR TITLE
Split main() into a separate module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ endif
 override LIBS += `pkg-config openssl --libs` $(SOCKET_LIBS) -pthread
 
 OBJS = \
-	relay.o \
+	main.o \
+	relaylog.o \
 	consistent-hash.o \
 	receptor.o \
 	dispatcher.o \

--- a/relay.h
+++ b/relay.h
@@ -18,6 +18,8 @@
 #ifndef HAVE_RELAY_H
 #define HAVE_RELAY_H 1
 
+#include <stdio.h>
+
 #define VERSION "0.39"
 
 #define METRIC_BUFSIZ 8192
@@ -26,8 +28,13 @@ enum rmode { NORMAL, DEBUG, SUBMISSION, TEST };
 
 typedef enum { CON_TCP, CON_UDP, CON_PIPE } serv_ctype;
 
-extern char relay_hostname[];
+extern char relay_hostname[256];
 extern enum rmode mode;
+
+extern char *relay_logfile;
+extern FILE *relay_stdout;
+extern FILE *relay_stderr;
+extern char relay_can_log;
 
 enum logdst { LOGOUT, LOGERR };
 

--- a/relaylog.c
+++ b/relaylog.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2013-2015 Fabian Groffen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <time.h>
+#include <assert.h>
+
+#include "relay.h"
+
+char relay_hostname[256];
+enum rmode mode = NORMAL;
+
+char *relay_logfile = NULL;
+FILE *relay_stdout = NULL;
+FILE *relay_stderr = NULL;
+char relay_can_log = 0;
+
+/**
+ * Writes to the setup output stream, prefixed with a timestamp, and if
+ * the stream is not going to stdout or stderr, prefixed with MSG or
+ * ERR.
+ */
+int
+relaylog(enum logdst dest, const char *fmt, ...)
+{
+	va_list ap;
+	char prefix[64];
+	size_t len;
+	time_t now;
+	struct tm *tm_now;
+	FILE *dst = NULL;
+	char console = 0;
+	int ret;
+
+	switch (dest) {
+		case LOGOUT:
+			dst = relay_stdout;
+			if (dst == stdout)
+				console = 1;
+			break;
+		case LOGERR:
+			dst = relay_stderr;
+			if (dst == stderr)
+				console = 1;
+			break;
+	}
+	assert(dst != NULL);
+
+	/* briefly stall if we're swapping fds */
+	while (!relay_can_log)
+		usleep((100 + (rand() % 200)) * 1000);  /* 100ms - 300ms */
+
+	time(&now);
+	tm_now = localtime(&now);
+	len = strftime(prefix, sizeof(prefix), "[%Y-%m-%d %H:%M:%S]", tm_now);
+
+	if (!console)
+		len += snprintf(prefix + len, sizeof(prefix) - len, " (%s)", dest == LOGOUT ? "MSG" : "ERR");
+
+	fprintf(dst, "%s ", prefix);
+
+	va_start(ap, fmt);
+
+	ret = vfprintf(dst, fmt, ap);
+	fflush(dst);
+
+	va_end(ap);
+
+	return ret;
+}


### PR DESCRIPTION
I needed this to create a utility program to work with carbon-c-relay, since too many things depended on some global variables in the main module.