### PR TITLE
Updated contrib files to build from git releases cleanly

### DIFF
--- a/contrib/relay.init
+++ b/contrib/relay.init
@@ -5,34 +5,34 @@
 #	relay    Startup script for the carbon-c-relay metrics aggregation daemon
 #	Packaged for the BBC by Matthew Hollick <matthew@mayan-it.co.uk>
 #
-# description: Carbon-like graphite line mode relay.\n
-#\n
-#This project aims to be a replacement of the original Carbon relay\n
-#\n
-#The main reason to build a replacement is performance and configurability.\n
-#Carbon is single threaded, and sending metrics to multiple consistent-hash\n
-#clusters requires chaining of relays. This project provides a multithreaded\n
-#relay which can address multiple targets and clusters for each and every\n
-#metric based on pattern matches.\n
+# description: Carbon-like graphite line mode relay.
+#
+#This project aims to be a replacement of the original Carbon relay
+#
+#The main reason to build a replacement is performance and configurability.
+#Carbon is single threaded, and sending metrics to multiple consistent-hash
+#clusters requires chaining of relays. This project provides a multithreaded
+#relay which can address multiple targets and clusters for each and every
+#metric based on pattern matches.
 #
 # chkconfig: 2345 80 80
 #
-# config: /etc/relay.conf
-# pidfile: /var/run/carbon/relay.pid
+# config: /etc/%%NAME%%.conf
+# pidfile: /var/run/%%NAME%%/%%NAME%%.pid
 
 # Source function library.
 . /etc/init.d/functions
 
 
 RETVAL=0
-PROG="relay"
+PROG="%%NAME%%"
 DAEMON_CONFIG=/etc/${PROG}.conf
 DAEMON_SYSCONFIG=/etc/sysconfig/${PROG}
 DAEMON=/usr/bin/${PROG}
-PID_FILE=/var/run/carbon/${PROG}.pid
+PID_FILE=/var/run/${PROG}/${PROG}.pid
 LOCK_FILE=/var/lock/subsys/${PROG}
-LOG_FILE=/var/log/carbon/relay.log
-DAEMON_USER="relay"
+LOG_FILE=/var/log/${PROG}/${PROG}.log
+DAEMON_USER="%%NAME%%"
 FQDN=$(hostname --long)
 
 . ${DAEMON_SYSCONFIG}

--- a/contrib/relay.logrotate
+++ b/contrib/relay.logrotate
@@ -1,5 +1,5 @@
 # not installed by default as logrotate is used to manage all carbon log files.
-/var/log/carbon/relay.log
+/var/log/%%NAME%%/%%NAME%%.log
 {
   sharedscripts
   missingok
@@ -7,6 +7,6 @@
   rotate 30
   compress
   postrotate
-        [ ! -f /var/run/carbon/relay.pid ] || /etc/init.d/relay restart
+        [ ! -f /var/run/%%NAME%%/%%NAME%%.pid ] || /etc/init.d/%%NAME%% restart
   endscript
 }

--- a/contrib/relay.monit
+++ b/contrib/relay.monit
@@ -1,6 +1,6 @@
 # Monit script to ensure carbon c relay is always running
-check process relay with pidfile /var/run/relay/relay.pid
-  start program = "/etc/init.d/relay start"
-  stop program = "/etc/init.d/relay stop"
+check process %%NAME%% with pidfile /var/run/%%NAME%%/%%NAME%%.pid
+  start program = "/etc/init.d/%%NAME%% start"
+  stop program = "/etc/init.d/%%NAME%% stop"
   if failed port 2003 type tcp then restart
   if 5 restarts within 5 cycles then timeout

--- a/contrib/relay.sysconfig
+++ b/contrib/relay.sysconfig
@@ -1,4 +1,4 @@
-#Usage: relay [-vdst] -f <config> [-p <port>] [-w <workers>] [-b <size>] [-q <size>]
+#Usage: %%NAME%% [-vdst] -f <config> [-p <port>] [-w <workers>] [-b <size>] [-q <size>]
 #
 #Options:
 #  -v  print version and exit


### PR DESCRIPTION
Also allows renaming of the daemon, if wanted, by just updating spec file param Name:
* updated spec file to use rpm macros where possible
* updated %setup to use carbon-c-relay as tar extracted location
* changed user/group to %{name}
* added placeholder %%NAME%% in init, logrotate, monit, sysconfig
 * added sed command to replace %%NAME%% in above at %prep stage
* added creation of /var/run/%{name} and /var/log/%{name}
* added chkconfig --add to %post
* added logrotate file to spec
* bump to version 0.39