### PR TITLE
Ensure metrics reported by relay are not cumulative

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -633,7 +633,10 @@ dispatch_reloadcomplete(dispatcher *d)
 inline size_t
 dispatch_get_ticks(dispatcher *self)
 {
-	return self->ticks;
+	size_t value;
+	value = self->ticks;
+	self->ticks = 0;
+	return value;
 }
 
 /**
@@ -642,7 +645,10 @@ dispatch_get_ticks(dispatcher *self)
 inline size_t
 dispatch_get_metrics(dispatcher *self)
 {
-	return self->metrics;
+	size_t value;
+	value = self->metrics;
+	self->metrics = 0;
+	return value;
 }
 
 /**

--- a/server.c
+++ b/server.c
@@ -652,9 +652,12 @@ server_failed(server *s)
 inline size_t
 server_get_ticks(server *s)
 {
-	if (s == NULL)
+	size_t value;
+        if (s == NULL)
 		return 0;
-	return s->ticks;
+	value = s->ticks;
+	s->ticks = 0;
+	return value;
 }
 
 /**
@@ -663,9 +666,12 @@ server_get_ticks(server *s)
 inline size_t
 server_get_metrics(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->metrics;
+	value = s->metrics;
+	s->metrics = 0;
+	return value;
 }
 
 /**
@@ -674,9 +680,12 @@ server_get_metrics(server *s)
 inline size_t
 server_get_dropped(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->dropped;
+	value = s->dropped;
+	s->dropped = 0;
+	return value;
 }
 
 /**
@@ -687,9 +696,12 @@ server_get_dropped(server *s)
 inline size_t
 server_get_stalls(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->stalls;
+	value = s->stalls;
+	s->stalls = 0;
+	return value;
 }
 
 /**


### PR DESCRIPTION
Since the metrics / dropped / etc counters are only used by the collector, it should be okay to reset them after use. This should make these carbon.relay.* metrics equivalent to the ones in the original python daemon.
