### PR TITLE
Provide an option for graphite-project style carbon.relay statistics

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -633,7 +633,10 @@ dispatch_reloadcomplete(dispatcher *d)
 inline size_t
 dispatch_get_ticks(dispatcher *self)
 {
-	return self->ticks;
+	size_t value;
+	value = self->ticks;
+	self->ticks = 0;
+	return value;
 }
 
 /**
@@ -642,7 +645,10 @@ dispatch_get_ticks(dispatcher *self)
 inline size_t
 dispatch_get_metrics(dispatcher *self)
 {
-	return self->metrics;
+	size_t value;
+	value = self->metrics;
+	self->metrics = 0;
+	return value;
 }
 
 /**

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -635,7 +635,8 @@ dispatch_get_ticks(dispatcher *self)
 {
 	size_t value;
 	value = self->ticks;
-	self->ticks = 0;
+	if (metric_style == GRAPHITE)
+		self->ticks = 0;
 	return value;
 }
 
@@ -647,7 +648,8 @@ dispatch_get_metrics(dispatcher *self)
 {
 	size_t value;
 	value = self->metrics;
-	self->metrics = 0;
+	if (metric_style == GRAPHITE)
+		self->metrics = 0;
 	return value;
 }
 

--- a/relay.c
+++ b/relay.c
@@ -39,6 +39,7 @@
 int keep_running = 1;
 char relay_hostname[256];
 enum rmode mode = NORMAL;
+enum mmode metric_style = CRELAY;
 
 static char *config = NULL;
 static int batchsize = 2500;
@@ -214,7 +215,7 @@ do_version(void)
 static void
 do_usage(int exitcode)
 {
-	printf("Usage: relay [-vdst] -f <config> [-p <port>] [-w <workers>] [-b <size>] [-q <size>]\n");
+	printf("Usage: relay [-vdmst] -f <config> [-p <port>] [-w <workers>] [-b <size>] [-q <size>]\n");
 	printf("\n");
 	printf("Options:\n");
 	printf("  -v  print version and exit\n");
@@ -226,6 +227,7 @@ do_usage(int exitcode)
 	printf("  -b  server send batch size, defaults to 2500\n");
 	printf("  -q  server queue size, defaults to 25000\n");
 	printf("  -S  statistics sending interval in seconds, defaults to 60\n");
+	printf("  -m  Use original graphite style statistics\n");
 	printf("  -c  characters to allow next to [A-Za-z0-9], defaults to -_:#\n");
 	printf("  -d  debug mode: currently writes statistics to log, prints hash\n"
 	       "      ring contents and matching position in test mode (-t)\n");
@@ -257,7 +259,7 @@ main(int argc, char * const argv[])
 	if (gethostname(relay_hostname, sizeof(relay_hostname)) < 0)
 		snprintf(relay_hostname, sizeof(relay_hostname), "127.0.0.1");
 
-	while ((ch = getopt(argc, argv, ":hvdstf:i:l:p:w:b:q:S:c:H:")) != -1) {
+	while ((ch = getopt(argc, argv, ":hvdmstf:i:l:p:w:b:q:S:c:H:")) != -1) {
 		switch (ch) {
 			case 'v':
 				do_version();
@@ -268,6 +270,9 @@ main(int argc, char * const argv[])
 				} else {
 					mode = DEBUG;
 				}
+				break;
+			case 'm':
+				metric_style = GRAPHITE;
 				break;
 			case 's':
 				mode = SUBMISSION;

--- a/relay.h
+++ b/relay.h
@@ -23,11 +23,13 @@
 #define METRIC_BUFSIZ 8192
 
 enum rmode { NORMAL, DEBUG, SUBMISSION, TEST, DEBUGTEST };
+enum mmode { CRELAY, GRAPHITE };
 
 typedef enum { CON_TCP, CON_UDP, CON_PIPE, CON_FILE } serv_ctype;
 
 extern char relay_hostname[];
 extern enum rmode mode;
+extern enum mmode metric_style;
 
 enum logdst { LOGOUT, LOGERR };
 

--- a/server.c
+++ b/server.c
@@ -656,7 +656,8 @@ server_get_ticks(server *s)
         if (s == NULL)
 		return 0;
 	value = s->ticks;
-	s->ticks = 0;
+	if (metric_style == GRAPHITE)
+		s->ticks = 0;
 	return value;
 }
 
@@ -670,7 +671,8 @@ server_get_metrics(server *s)
 	if (s == NULL)
 		return 0;
 	value = s->metrics;
-	s->metrics = 0;
+	if (metric_style == GRAPHITE)
+		s->metrics = 0;
 	return value;
 }
 
@@ -684,7 +686,8 @@ server_get_dropped(server *s)
 	if (s == NULL)
 		return 0;
 	value = s->dropped;
-	s->dropped = 0;
+	if (metric_style == GRAPHITE)
+		s->dropped = 0;
 	return value;
 }
 
@@ -700,7 +703,8 @@ server_get_stalls(server *s)
 	if (s == NULL)
 		return 0;
 	value = s->stalls;
-	s->stalls = 0;
+	if (metric_style == GRAPHITE)
+		s->stalls = 0;
 	return value;
 }
 

--- a/server.c
+++ b/server.c
@@ -652,9 +652,12 @@ server_failed(server *s)
 inline size_t
 server_get_ticks(server *s)
 {
-	if (s == NULL)
+	size_t value;
+        if (s == NULL)
 		return 0;
-	return s->ticks;
+	value = s->ticks;
+	s->ticks = 0;
+	return value;
 }
 
 /**
@@ -663,9 +666,12 @@ server_get_ticks(server *s)
 inline size_t
 server_get_metrics(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->metrics;
+	value = s->metrics;
+	s->metrics = 0;
+	return value;
 }
 
 /**
@@ -674,9 +680,12 @@ server_get_metrics(server *s)
 inline size_t
 server_get_dropped(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->dropped;
+	value = s->dropped;
+	s->dropped = 0;
+	return value;
 }
 
 /**
@@ -687,9 +696,12 @@ server_get_dropped(server *s)
 inline size_t
 server_get_stalls(server *s)
 {
+        size_t value;
 	if (s == NULL)
 		return 0;
-	return s->stalls;
+	value = s->stalls;
+	s->stalls = 0;
+	return value;
 }
 
 /**


### PR DESCRIPTION
Reimplemented PR for making carbon.relay.* metrics compatible with graphite-project equivalents.

Existing functionality continues by default. To select backwardly compatible metrics you need to specify the '-m' command line switch.
