### PR TITLE
Stop looking for replicas if we don't actually have that many

### DIFF
--- a/consistent-hash.c
+++ b/consistent-hash.c
@@ -44,6 +44,7 @@ struct _ch_ring {
 	ch_type type;
 	unsigned char hash_replicas;
 	ch_ring_entry *entries;
+	int size; // Number of servers added
 };
 
 
@@ -144,6 +145,7 @@ ch_new(ch_type type)
 	ret->type = type;
 	ret->hash_replicas = HASH_REPLICAS;
 	ret->entries = NULL;
+	ret->size = 0;
 
 	return ret;
 }
@@ -255,6 +257,7 @@ ch_addnode(ch_ring *ring, server *s)
 		}
 	}
 
+	ring->size += 1;
 	return ring;
 }
 
@@ -288,6 +291,10 @@ ch_get_nodes(
 
 	assert(ring->entries);
 
+	/* If there are less than replcnt entries in the ring, we need to only return
+	 * entries in the ring, or else we will spin forever finding unique entries. */
+	int limited_replcnt = replcnt > ring->size ? ring->size : replcnt;
+
 	/* implement behaviour of Python's bisect_left on the ring (used in
 	 * carbon hash source), one day we might want to implement it as
 	 * real binary search iso forward pointer chasing */
@@ -295,7 +302,7 @@ ch_get_nodes(
 		if (w->pos >= pos)
 			break;
 	/* now fetch enough unique servers to match the requested count */
-	for (i = 0; i < replcnt; i++, w = w->next) {
+	for (i = 0; i < limited_replcnt; i++, w = w->next) {
 		if (w == NULL)
 			w = ring->entries;
 		for (j = i - 1; j >= 0; j--) {

--- a/consistent-hash.c
+++ b/consistent-hash.c
@@ -151,6 +151,17 @@ ch_new(ch_type type)
 }
 
 /**
+ * Return the number of servers added to this ring.
+ */
+int
+ch_size(ch_ring *ring)
+{
+	if (ring == NULL)
+		return -1;
+	return ring->size;
+}
+
+/**
  * Computes the hash positions for the server name given.  This is based
  * on the hashpos function.  The server name usually is the IPv4
  * address.  The port component is just stored and not used in the

--- a/consistent-hash.h
+++ b/consistent-hash.h
@@ -30,6 +30,7 @@ typedef CH_RING ch_ring;
 typedef enum { CARBON, FNV1a } ch_type;
 
 ch_ring *ch_new(ch_type type);
+int ch_size(ch_ring *ring);
 ch_ring *ch_addnode(ch_ring *ring, server *s);
 void ch_get_nodes(
 		destination ret[],

--- a/router.c
+++ b/router.c
@@ -694,6 +694,12 @@ router_readconfig(cluster **clret, route **rret,
 				for (; *p != '\0' && isspace(*p); p++)
 					;
 			} while (*p != ';');
+
+			if (cl->members.ch && ch_size(cl->members.ch->ring) < cl->members.ch->repl_factor)
+				logerr("cluster under-replicated: %d nodes specified with a replication of %d",
+				       ch_size(cl->members.ch->ring),
+				       cl->members.ch->repl_factor);
+
 			p++; /* skip over ';' */
 			if (cl->type == ANYOF || cl->type == FAILOVER) {
 				size_t i = 0;


### PR DESCRIPTION
If you specify replicas of a number greater than the number of hosts specified, this function will spin forever. This is incidentally a test configuration I use.

This isn't perfect, but at least avoids 100% * workers CPU usage by just returning the contents of the ring.