### PR TITLE
router: Fix segfault in router_test

### DIFF
--- a/router.c
+++ b/router.c
@@ -2542,7 +2542,7 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 							x = "!impossible?";
 							break;
 					}
-					fprintf(stdout, "    %s [%s: %s]\n    -> %s\n",
+					fprintf(stdout, "    %s [%s: %s] -> %s\n",
 							w->pattern, x, w->strmatch, metric);
 				}	break;
 			}
@@ -2582,7 +2582,7 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 									break;
 								}
 								snprintf(newmetric, sizeof(newmetric),
-										"%s", ac->metric + stublen);
+										"%s%s", ac->metric + stublen, firstspace);
 							}
 
 							snprintf(percentile, sizeof(percentile),
@@ -2598,14 +2598,7 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 									w->nmatch > 0 ? "(" : "",
 									w->nmatch > 0 ? ac->metric + stublen : "",
 									w->nmatch > 0 ? ")" : "",
-									newmetric + stublen);
-						}
-						if (stublen > 0) {
-							gotmatch |= router_test_intern(
-									newmetric,
-									newfirstspace,
-									routes);
-							return gotmatch;
+									w->nmatch > 0 ? (newmetric + stublen) : newmetric);
 						}
 					}	break;
 					case BLACKHOLE: {


### PR DESCRIPTION
Testing the router wasn't printing the routes properly, ending with a segfault.

Configuration:
```
cluster test
    file
        test.out
    ;

aggregate
        ^test1\.(.*)
    every 10 seconds
    expire after 30 seconds
    compute sum write to
        aggregates.sum.test
    compute max write to
        aggregates.max.test
    send to test
    stop
    ;

aggregate
        ^test2\.
    every 10 seconds
    expire after 30 seconds
    compute sum write to
        aggregates.sum.test
    compute max write to
        aggregates.max.test
    send to test
    stop
    ;

match *
    send to test
    stop
    ;
```
Before:
```
test1.foo <<<
aggregation
    ^test1\.(.*) (regex) -> test1.foo
    sum(aggregates.sum.test) -> aggregates.sum.test <<<
    max(aggregates.max.test) -> aggregates.max.test <<<
match
    * -> aggregates.max.test <<<
    cluster(test)
    stop

test2.foo <<<
aggregation
    ^test2\. [strncmp: test2.]
    -> test2.foo
    sum -> aggregates.max.test <<<
    max -> aggregates.max.test <<<
Segmentation fault
```
After:
```
test1.foo <<<
aggregation
    ^test1\.(.*) (regex) -> test1.foo
    sum(aggregates.sum.test) -> aggregates.sum.test <<<
    max(aggregates.max.test) -> aggregates.max.test <<<
    cluster(test)
    stop

test2.foo <<<
aggregation
    ^test2\. [strncmp: test2.] -> test2.foo
    sum -> aggregates.sum.test <<<
    max -> aggregates.max.test <<<
    cluster(test)
    stop
```