### PR TITLE
Fix typo detected by Debian's lintian

### DIFF
--- a/router.c
+++ b/router.c
@@ -914,7 +914,7 @@ router_readconfig(cluster **clret, route **rret, aggregator **aret,
 
 			if (matchcatchallfound) {
 				logerr("warning: match %s will never be matched "
-						"due to preceeding match * ... stop\n",
+						"due to preceding match * ... stop\n",
 						r->pattern == NULL ? "*" : r->pattern);
 			}
 			if (r->matchtype == MATCHALL && r->stop)


### PR DESCRIPTION
I: carbon-c-relay: spelling-error-in-binary usr/bin/carbon-c-relay preceeding preceding
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.