### PR TITLE
hup_handler: Return from handler if no config changes

### DIFF
--- a/relay.c
+++ b/relay.c
@@ -179,6 +179,7 @@ hup_handler(int sig)
 		logout("no config changes found\n");
 		router_free(newrtr);
 		logout("SIGHUP handler complete\n");
+		return;
 	}
 
 	logout("reloading collector\n");


### PR DESCRIPTION
Otherwise `hup_handler` starts trying to use the `newrtr` pointer that has just been freed.