### PR TITLE
router_readconfig: position a at the end of chain also.

### DIFF
--- a/router.c
+++ b/router.c
@@ -425,7 +425,9 @@ router_readconfig(router *orig,
 		ret->clusters = cl;
 	} else {
 		ret = orig;
-		/* position cl and r at the end of chains */
+		/* position a, cl and r at the end of chains */
+		for (a = ret->aggregators; a != NULL && a->next != NULL; a = a->next)
+			;
 		for (cl = ret->clusters; cl->next != NULL; cl = cl->next)
 			;
 		for (r = ret->routes; r != NULL && r->next != NULL; r = r->next)


### PR DESCRIPTION
When reading from multiple files, this makes sure that new aggregation rules are appended to the end of the global ret->aggregator list, rather than overwriting it with each new 'include'.

Closes #180