### PR TITLE
router_readconfig: adjust a, cl, and r after reading all includes.

### DIFF
--- a/issues/issue180-a.conf
+++ b/issues/issue180-a.conf
@@ -1,0 +1,3 @@
+match baz
+    send to blackhole
+    ;

--- a/issues/issue180.conf
+++ b/issues/issue180.conf
@@ -1,0 +1,10 @@
+match foo
+    send to blackhole
+    ;
+
+include issue180-a.conf
+    ;
+
+match bar
+    send to blackhole
+    ;

--- a/router.c
+++ b/router.c
@@ -1869,6 +1869,14 @@ router_readconfig(router *orig,
 			if (ret == NULL)
 				/* router_readconfig already barked and freed ret */
 				return NULL;
+			/* the included file could have added new aggregates, matches, or clusters,
+			 * so adjust these chains to point to the new end. */
+			for (; a != NULL && a->next != NULL; a = a->next)
+				;
+			for (; cl->next != NULL; cl = cl->next)
+				;
+			for (; r != NULL && r->next != NULL; r = r->next)
+				;
 			*p = endchar;
 			for (; *p != '\0' && isspace(*p); p++)
 				;


### PR DESCRIPTION
Another symptom that can cause rules to be overwritten as in #180.

After finishing parsing all includes, update local chain to point to the "new" end of the linked list.

Added a testcase in issues, the expected output is:
```
match foo
    send to blackhole
    stop
    ;
match baz
    send to blackhole
    stop
    ;
match bar
    send to blackhole
    stop
    ;
```
Without this change, `match baz` disappears.