### PR TITLE
Error handling when Git is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 CFLAGS ?= -O2 -Wall -Wshadow
 
-GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always || date +%F)
+GIT_VERSION := $(shell type git >/dev/null && git describe --abbrev=6 --dirty --always || date +%F)
 GVCFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
 
 override CFLAGS += $(GVCFLAGS) -pthread


### PR DESCRIPTION
Simple test to see if the `git` command actually exists before attempting to run it in the Makefile. I build from release tarball in a very minimal busybox-based Docker container that doesn't have git, and the compilation will fail in that case. 
