### PR TITLE
Match route using

### DIFF
--- a/carbon-c-relay.md
+++ b/carbon-c-relay.md
@@ -310,6 +310,11 @@ taken with the latter to avoid log flooding.  When a validate clause is
 present, destinations need not to be present, this allows for applying a
 global validation rule.  Note that the cleansing rules are applied
 before validation is done, thus the data will not have duplicate spaces.
+The `route using` clause is used to perform a temporary modification to
+the key used for input to the consistent hashing routines.  The primary
+purpose is to route traffic so that appropriate data is sent to the
+needed aggregation instances.
+
 
 Rewrite rules take a regular input to match incoming metrics, and
 transform them into the desired new metric name.  In the replacement,

--- a/router.c
+++ b/router.c
@@ -1169,8 +1169,6 @@ router_readconfig(router *orig,
 				}
 
 			}
-// route using
-// XXX
 			if (*p == 'r') {
 				p += 6;
 				for (; *p != '\0' && isspace(*p); p++)
@@ -1207,7 +1205,7 @@ router_readconfig(router *orig,
 				d->cl->name = NULL;
 				d->cl->type = ROUTE_USING;
 				d->cl->next = NULL;
-	
+
 				if (*p == '\0') {
 					logerr("unexpected end of file after 'route using %s'\n",
 							replacement);
@@ -1219,7 +1217,6 @@ router_readconfig(router *orig,
 				*p++ = '\0';
 				for (; *p != '\0' && isspace(*p); p++)
 					;
-// Save the replacement somewhere
 				d->cl->members.replacement = ra_strdup(ret, replacement);
 			}
 			p += 5;
@@ -3226,16 +3223,16 @@ router_route_intern(
 					case ROUTE_USING: {
 						if ((len = router_rewrite_metric(
 									&newmetric, &newfirstspace,
- 									metric, firstspace,
- 									d->cl->members.replacement,
- 									w->nmatch, pmatch)) == 0)
- 						{
- 							fprintf(stderr, "router_test: failed to transform "
- 									"metric: newmetric size too small to hold "
- 									"replacement (%s -> %s)\n",
- 									metric, d->cl->members.replacement);
- 							break;
- 						};
+									metric, firstspace,
+									d->cl->members.replacement,
+									w->nmatch, pmatch)) == 0)
+						{
+							fprintf(stderr, "router_test: failed to transform "
+									"metric: newmetric size too small to hold "
+									"replacement (%s -> %s)\n",
+									metric, d->cl->members.replacement);
+							break;
+						};
 
 						route_using = 1;
 					}
@@ -3547,16 +3544,16 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 					case ROUTE_USING: {
 						if ((len = router_rewrite_metric(
 									&newmetric, &newfirstspace,
- 									metric, firstspace,
- 									d->cl->members.replacement,
- 									w->nmatch, pmatch)) == 0)
- 						{
- 							fprintf(stderr, "router_test: failed to transform "
- 									"metric: newmetric size too small to hold "
- 									"replacement (%s -> %s)\n",
- 									metric, d->cl->members.replacement);
- 							break;
- 						};
+									metric, firstspace,
+									d->cl->members.replacement,
+									w->nmatch, pmatch)) == 0)
+						{
+							fprintf(stderr, "router_test: failed to transform "
+									"metric: newmetric size too small to hold "
+									"replacement (%s -> %s)\n",
+									metric, d->cl->members.replacement);
+							break;
+						};
 						*newfirstspace = '\0';
 						fprintf(stdout, "    route using %s\n",
 								d->cl->members.replacement);

--- a/router.c
+++ b/router.c
@@ -1249,6 +1249,7 @@ router_readconfig(router *orig,
 							w->type != AGGREGATION &&
 							w->type != REWRITE &&
 							w->type != VALIDATION &&
+							w->type != ROUTE_USING &&
 							strcmp(w->name, dest) == 0)
 						break;
 				}
@@ -1621,6 +1622,7 @@ router_readconfig(router *orig,
 								cw->type != AGGREGATION &&
 								cw->type != REWRITE &&
 								cw->type != VALIDATION &&
+								cw->type != ROUTE_USING &&
 								strcmp(cw->name, dest) == 0)
 							break;
 					}
@@ -1907,6 +1909,7 @@ router_readconfig(router *orig,
 							cw->type != AGGREGATION &&
 							cw->type != REWRITE &&
 							cw->type != VALIDATION &&
+							cw->type != ROUTE_USING &&
 							strcmp(cw->name, dest) == 0)
 						break;
 				}
@@ -2651,7 +2654,7 @@ router_printconfig(router *rtr, FILE *f, char pmode)
 				/* hide this pseudo target */
 				d = d->next;
 			}
-			if (d->cl->type == ROUTE_USING) {
+			if (d != NULL && d->cl->type == ROUTE_USING) {
 				fprintf(f, "    route using %s\n",
 						d->cl->members.replacement);
 				/* hide this pseudo target */

--- a/router.c
+++ b/router.c
@@ -43,6 +43,7 @@ enum clusttype {
 	AGGRSTUB,   /* pseudo type to have stub matches for aggregation returns */
 	STATSTUB,   /* pseudo type to have stub matches for collector returns */
 	VALIDATION, /* pseudo type to perform additional data validation */
+	ROUTE_USING,/* pseudo type to perform temporary key pattern changes prior to routing */
 	FORWARD,
 	FILELOG,    /* like forward, write metric to file */
 	FILELOGIP,  /* like forward, write ip metric to file */
@@ -265,6 +266,9 @@ router_free_intern(cluster *clusters, route *routes)
 			case AGGRSTUB:
 			case STATSTUB:
 			case VALIDATION:
+				/* handled at the routes above */
+				break;
+			case ROUTE_USING:
 				/* handled at the routes above */
 				break;
 			case AGGREGATION:
@@ -1017,7 +1021,7 @@ router_readconfig(router *orig,
 					r->matchtype = MATCHALL;
 				} else {
 					int err = determine_if_regex(r, pat,
-							REG_EXTENDED | REG_NOSUB);
+							REG_EXTENDED);
 					if (err != 0) {
 						char ebuf[512];
 						regerror(err, &r->rule, ebuf, sizeof(ebuf));
@@ -1029,7 +1033,8 @@ router_readconfig(router *orig,
 				}
 			} while (
 					(strncmp(p, "send", 4) != 0 || !isspace(*(p + 4))) &&
-					(strncmp(p, "validate", 8) != 0 || !isspace(*(p + 8))));
+					(strncmp(p, "validate", 8) != 0 || !isspace(*(p + 8))) &&
+					(strncmp(p, "route", 5) != 0 || !isspace(*(p + 5))));
 			if (*p == 'v') {
 				p += 9;
 
@@ -1162,11 +1167,59 @@ router_readconfig(router *orig,
 					continue;
 				}
 
-				if (strncmp(p, "send", 4) != 0 || !isspace(*(p + 4))) {
-					logerr("expected 'send to' after validate %s\n", pat);
+			}
+// route using
+// XXX
+			if (*p == 'r') {
+				p += 6;
+				for (; *p != '\0' && isspace(*p); p++)
+					;
+				if (strncmp(p, "using", 5) != 0 || !isspace(*(p + 5))) {
+					logerr("expected 'using' after 'route' for match %s\n",
+							r->pattern ? r->pattern : "*");
 					router_free(ret);
 					return NULL;
 				}
+				p += 5;
+				for (; *p != '\0' && isspace(*p); p++)
+					;
+				char *replacement = p;
+
+				if (dw == NULL) {
+					dw = d = ra_malloc(ret, sizeof(destinations));
+				} else {
+					d = d->next = ra_malloc(ret, sizeof(destinations));
+				}
+				if (d == NULL) {
+					logerr("out of memory allocating new route using "
+							"for 'match %s'\n", pat);
+					router_free(ret);
+					return NULL;
+				}
+				d->next = NULL;
+				if ((d->cl = ra_malloc(ret, sizeof(cluster))) == NULL) {
+					logerr("malloc failed for route using rule in 'match %s'\n",
+							pat);
+					router_free(ret);
+					return NULL;
+				}
+				d->cl->name = NULL;
+				d->cl->type = ROUTE_USING;
+				d->cl->next = NULL;
+	
+				if (*p == '\0') {
+					logerr("unexpected end of file after 'route using %s'\n",
+							replacement);
+					router_free(ret);
+					return NULL;
+				}
+				for (; *p != '\0' && !isspace(*p); p++)
+					;
+				*p++ = '\0';
+				for (; *p != '\0' && isspace(*p); p++)
+					;
+// Save the replacement somewhere
+				d->cl->members.replacement = ra_strdup(ret, replacement);
 			}
 			p += 5;
 			for (; *p != '\0' && isspace(*p); p++)
@@ -2597,6 +2650,12 @@ router_printconfig(router *rtr, FILE *f, char pmode)
 				/* hide this pseudo target */
 				d = d->next;
 			}
+			if (d->cl->type == ROUTE_USING) {
+				fprintf(f, "    route using %s\n",
+						d->cl->members.replacement);
+				/* hide this pseudo target */
+				d = d->next;
+			}
 			if (d != NULL) {
 				fprintf(f, "    send to");
 				if (d->next == NULL) {
@@ -2957,6 +3016,7 @@ router_route_intern(
 	char newmetric[METRIC_BUFSIZ];
 	char *newfirstspace = NULL;
 	size_t len;
+	int route_using = 0;
 	regmatch_t pmatch[RE_MAX_MATCHES];
 
 #define failif(RETLEN, WANTLEN) \
@@ -3071,12 +3131,18 @@ router_route_intern(
 						/* let the ring(bearer) decide */
 						failif(retsize,
 								*curlen + d->cl->members.ch->repl_factor);
+						char *key = metric;
+						char *space = firstspace;
+						if (route_using) {
+							key = newmetric;
+							space = newfirstspace;
+						}
 						ch_get_nodes(
 								&ret[*curlen],
 								d->cl->members.ch->ring,
 								d->cl->members.ch->repl_factor,
-								metric,
-								firstspace);
+								key,
+								space);
 						*curlen += d->cl->members.ch->repl_factor;
 						wassent = 1;
 					}	break;
@@ -3153,6 +3219,22 @@ router_route_intern(
 							d = d->next;
 						break;
 					}
+					case ROUTE_USING: {
+						if ((len = router_rewrite_metric(
+									&newmetric, &newfirstspace,
+ 									metric, firstspace,
+ 									d->cl->members.replacement,
+ 									w->nmatch, pmatch)) == 0)
+ 						{
+ 							fprintf(stderr, "router_test: failed to transform "
+ 									"metric: newmetric size too small to hold "
+ 									"replacement (%s -> %s)\n",
+ 									metric, d->cl->members.replacement);
+ 							break;
+ 						};
+
+						route_using = 1;
+					}
 					case GROUP: {
 						/* this should not happen */
 					}	break;
@@ -3210,6 +3292,7 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 	char newmetric[METRIC_BUFSIZ];
 	char *newfirstspace = NULL;
 	size_t len;
+	int route_using = 0;
 	regmatch_t pmatch[RE_MAX_MATCHES];
 
 	for (w = routes; w != NULL; w = w->next) {
@@ -3384,6 +3467,12 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 						destination dst[CONN_DESTS_SIZE];
 						int i;
 
+						char *key = metric;
+						char *space = firstspace;
+						if (route_using) {
+							key = newmetric;
+							space = newfirstspace;
+						}
 						fprintf(stdout, "    %s_ch(%s)\n",
 								d->cl->type == CARBON_CH ? "carbon" :
 								d->cl->type == FNV1A_CH ? "fnv1a" :
@@ -3393,19 +3482,22 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 						if (mode & MODE_DEBUG) {
 							fprintf(stdout, "        hash_pos(%d)\n",
 									ch_gethashpos(d->cl->members.ch->ring,
-										metric, firstspace));
+										key, space));
 						}
 						ch_get_nodes(dst,
 								d->cl->members.ch->ring,
 								d->cl->members.ch->repl_factor,
-								metric,
-								firstspace);
+								key,
+								space);
+						*firstspace = '\0';
 						for (i = 0; i < d->cl->members.ch->repl_factor; i++) {
-							fprintf(stdout, "        %s:%d\n",
+							fprintf(stdout, "        %s  ->  %s:%d\n",
+									metric,
 									server_ip(dst[i].dest),
 									server_port(dst[i].dest));
 							free((char *)dst[i].metric);
 						}
+						*firstspace = ' ';
 					}	break;
 					case FAILOVER:
 					case ANYOF: {
@@ -3447,6 +3539,25 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 							while (d->next != NULL)
 								d = d->next;
 						}
+					}	break;
+					case ROUTE_USING: {
+						if ((len = router_rewrite_metric(
+									&newmetric, &newfirstspace,
+ 									metric, firstspace,
+ 									d->cl->members.replacement,
+ 									w->nmatch, pmatch)) == 0)
+ 						{
+ 							fprintf(stderr, "router_test: failed to transform "
+ 									"metric: newmetric size too small to hold "
+ 									"replacement (%s -> %s)\n",
+ 									metric, d->cl->members.replacement);
+ 							break;
+ 						};
+						*newfirstspace = '\0';
+						fprintf(stdout, "    route using %s\n",
+								d->cl->members.replacement);
+						*newfirstspace = ' ';
+						route_using = 1;
 					}	break;
 					default: {
 						fprintf(stdout, "    cluster(%s)\n", d->cl->name);


### PR DESCRIPTION
The purpose is to perform a temporary modification on the key so
that all of the appropriate keys end up on the same aggregation
instance.

This re-uses the rewrite methods to perform the modification of the
key, so the same functionality exists.  This does not affect the
metric key sent downstream.  It only affects the key used to
perform the routing.

Sample configuration would be:
cluster carbon
  carbon_ch
    10.0.0.1:2003=a
    10.0.0.1:2004=b
    10.0.0.1:2005=c
    10.0.0.1:2006=d
    10.0.0.2:2003=a
    10.0.0.2:2004=b
    10.0.0.2:2005=c
    10.0.0.2:2006=d

match ^collection\.([^.]+)\.([^.]+)\.([^.]+)\.[^.]+\.(.+)
  route using collection.\1.\2.\3.\4
  send to carbon
  stop
  ;

match *
  send to carbon
  stop
  ;
