### PR TITLE
Split regex_t to one per thread

### DIFF
--- a/conffile.h
+++ b/conffile.h
@@ -85,7 +85,7 @@ typedef struct _destinations {
 
 typedef struct _route {
 	char *pattern;    /* original regex input, used for printing only */
-	regex_t rule;     /* regex on metric, only if type == REGEX */
+	regex_t *rule;     /* regex on metric, only if type == REGEX */
 	size_t nmatch;    /* number of match groups */
 	char *strmatch;   /* string to search for if type not REGEX or MATCHALL */
 	destinations *dests; /* where matches should go */

--- a/dispatcher.c
+++ b/dispatcher.c
@@ -449,7 +449,7 @@ dispatch_connection(connection *conn, dispatcher *self, struct timeval start)
 						router_route(self->rtr,
 						conn->dests, &conn->destlen, CONN_DESTS_SIZE,
 						conn->srcaddr,
-						conn->metric, firstspace));
+						conn->metric, firstspace, self->id));
 				tracef("dispatcher %d, connfd %d, destinations %zd\n",
 						self->id, conn->sock, conn->destlen);
 

--- a/relay.c
+++ b/relay.c
@@ -45,6 +45,7 @@ unsigned char keep_running = 1;
 int pending_signal = -1;
 char relay_hostname[256];
 unsigned char mode = 0;
+char workercnt = 0;
 
 static char *config = NULL;
 static int batchsize = 2500;
@@ -56,7 +57,6 @@ static int sockbufsize = 0;
 static int collector_interval = 60;
 static col_mode smode = CUM;
 static dispatcher **workers = NULL;
-static char workercnt = 0;
 static router *rtr = NULL;
 static server *internal_submission = NULL;
 static char *relay_logfile = NULL;

--- a/relay.h
+++ b/relay.h
@@ -40,6 +40,7 @@ extern unsigned char mode;
 #endif
 
 extern char relay_hostname[];
+extern char workercnt;
 
 enum logdst { LOGOUT, LOGERR };
 

--- a/router.h
+++ b/router.h
@@ -48,7 +48,7 @@ void router_transplant_queues(router *new, router *old);
 char router_start(router *r);
 size_t router_rewrite_metric(char (*newmetric)[METRIC_BUFSIZ], char **newfirstspace, const char *metric, const char *firstspace, const char *replacement, const size_t nmatch, const regmatch_t *pmatch);
 void router_printconfig(router *r, FILE *f, char mode);
-char router_route(router *r, destination ret[], size_t *retcnt, size_t retsize, char *srcaddr, char *metric, char *firstspace);
+char router_route(router *r, destination ret[], size_t *retcnt, size_t retsize, char *srcaddr, char *metric, char *firstspace, int dispatcher_id);
 void router_test(router *r, char *metric_path);
 server **router_getservers(router *r);
 aggregator *router_getaggregators(router *r);


### PR DESCRIPTION
When using carbon-c-relay to perform metric aggregation, `strace` found a lot of calls to `futex`. Using `gdb`, I discovered that we were frequently blocking on a mutex in the regex matching operations. By compiling a separate `regex_t` for each dispatcher, we can avoid blocking when matching metric names.