### PR TITLE
Correct `route using` from sending the rewritten key

### DIFF
--- a/consistent-hash.c
+++ b/consistent-hash.c
@@ -303,7 +303,8 @@ ch_get_nodes(
 		ch_ring *ring,
 		const char replcnt,
 		const char *metric,
-		const char *firstspace)
+		const char *firstspace,
+                const char *realmetric)
 {
 	unsigned short pos = 0;
 	int i, j, t;
@@ -403,7 +404,7 @@ ch_get_nodes(
 			continue;
 		}
 		ret[i].dest = ring->entrylist[t].server;
-		ret[i].metric = strdup(metric);
+		ret[i].metric = strdup(realmetric);
 	}
 }
 

--- a/consistent-hash.h
+++ b/consistent-hash.h
@@ -37,7 +37,8 @@ void ch_get_nodes(
 		ch_ring *ring,
 		const char replcnt,
 		const char *metric,
-		const char *firstspace);
+		const char *firstspace,
+                const char *realmetric);
 void ch_printhashring(ch_ring *ring, FILE *out);
 unsigned short ch_gethashpos(ch_ring *ring, const char *key, const char *end);
 

--- a/router.c
+++ b/router.c
@@ -2543,7 +2543,8 @@ router_route_intern(
 								d->cl->members.ch->ring,
 								d->cl->members.ch->repl_factor,
 								w->masq ? newmetric : metric,
-								w->masq ? newfirstspace : firstspace);
+								w->masq ? newfirstspace : firstspace,
+								metric);
 						*curlen += d->cl->members.ch->repl_factor;
 						wassent = 1;
 					}	break;
@@ -2898,7 +2899,8 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 								d->cl->members.ch->ring,
 								d->cl->members.ch->repl_factor,
 								w->masq ? newmetric : metric,
-								w->masq ? newfirstspace : firstspace);
+								w->masq ? newfirstspace : firstspace,
+								metric);
 						for (i = 0; i < d->cl->members.ch->repl_factor; i++) {
 							fprintf(stdout, "        %s:%d\n",
 									serverip(dst[i].dest),


### PR DESCRIPTION
Only use the rewritten key for determining where to route.  It shouldn't send the rewritten key.