### PR TITLE
set TCP_USER_TIMEOUT to 10 seconds

### DIFF
--- a/server.c
+++ b/server.c
@@ -399,6 +399,16 @@ server_queuereader(void *d)
 								&args, sizeof(args)) != 0)
 						; /* ignore */
 
+#ifdef TCP_USER_TIMEOUT
+					/* break out of connections when no ACK is being received for
+					 * +- 10 seconds instead of retransmitting for +- 15 minutes
+					 * available on linux >= 2.6.37 */
+					args = 10000 + (rand() % 300);
+					if (setsockopt(self->fd, IPPROTO_TCP, TCP_USER_TIMEOUT,
+								&args, sizeof(args)) != 0)
+						; /* ignore */
+#endif
+
 					/* if we reached up here, we're good to go, so don't
 					 * continue with the other addrinfos */
 					break;


### PR DESCRIPTION
This sets the TCP_USER_TIMEOUT to 10 seconds on outgoing connections.

When for some reason no ACK's are being received on an ESTABLISHED connection
the kernel will start retransmitting. On my system (Fedora 25) it takes about
15 minutes before the kernel decides to give up and return an error. This
reduces this time to 10 seconds so the relay can close the connection and open
a new one.