### PR TITLE
added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM alpine:3.6
+
+MAINTAINER Tim Ehlers <ehlerst@gmail.com>
+
+RUN mkdir -p /opt/carbon-c-relay-build
+
+RUN mkdir /etc/carbon-c-relay
+
+COPY . /opt/carbon-c-relay-build
+
+RUN \
+  apk --no-cache update && \
+  apk --no-cache upgrade && \
+  apk --no-cache add git bc build-base curl && \
+  cd /opt/carbon-c-relay-build && \
+  ./configure; make && \
+  cp relay /usr/bin/carbon-c-relay && \
+  apk del --purge git bc build-base ca-certificates curl && \
+  rm -rf /opt/* /tmp/* /var/cache/apk/* /opt/carbon-c-relay-build
+
+EXPOSE 2003
+
+ENTRYPOINT ["carbon-c-relay", "-f", "/etc/carbon-c-relay/carbon-c-relay.conf"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-MAINTAINER Tim Ehlers <ehlerst@gmail.com>
+MAINTAINER Fabian Groffen
 
 RUN mkdir -p /opt/carbon-c-relay-build
 


### PR DESCRIPTION
This gets the image down to  6.531 MB which is pretty good. Usage is kept simple as its the core project, other projects should build off this image with templating and whatever other bells and whistles are desired.

I tried to not have Dockerfile in the main repo... however the COPY cannot execute down directory’s on dockerhub that im guessing are for security reasons.

Anyhow, the next step is to add this as an automated build to dockerhub which only the repo owner can do. Its free and removes allot of the hassle out of building. 

The tags will only build when you push a tag and master builds on all master pushes if you add this. 
![screenshot from 2017-07-10 19-10-29](https://user-images.githubusercontent.com/652083/28045589-a28da614-65a3-11e7-8939-28721e3789dc.png)

if we want to publish pre-3.1 i had to do some funny stuff in my repo here:
https://github.com/ehlerst/carbon-c-relay-docker 
https://github.com/ehlerst/carbon-c-relay-docker/blob/master/Dockerfile#L17
This doesn’t really fit in the automated way of building though i think...

Let me know what you think and ill update when i can.

Thanks!