### PR TITLE
Add conffile.tab.h as dependency on router.c in Makefile to fix parallel builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,8 @@ conffile.tab.c conffile.tab.h: conffile.y
 conffile.yy.c: conffile.l conffile.tab.h
 	flex -o $@ $<
 
+router.c: conffile.tab.h
+
 man:
 	sed -e '/travis-ci.org\/grobian\/carbon-c-relay.svg/d' carbon-c-relay.md | \
 	ronn \

--- a/Makefile.in
+++ b/Makefile.in
@@ -942,6 +942,8 @@ conffile.tab.c conffile.tab.h: conffile.y
 conffile.yy.c: conffile.l conffile.tab.h
 	flex -o $@ $<
 
+router.c: conffile.tab.h
+
 man:
 	sed -e '/travis-ci.org\/grobian\/carbon-c-relay.svg/d' carbon-c-relay.md | \
 	ronn \


### PR DESCRIPTION
In Fedora/EPEL rpm specfile we delete "conffile.tab.c conffile.tab.h conffile.yy.c" and regenerate them. router.c includes "conffile.tab.h" but there is no dependency defined in the Makefile making the order of compiles undefined. This (sometimes) fails on multicore systems with parallel builds enabled when router.c is being compiled before "conffile.tab.h" is done.

This simply defines the dependency.