### PR TITLE
syslog compatible server type

### DIFF
--- a/conffile.l
+++ b/conffile.l
@@ -81,7 +81,7 @@ cluster				{
 <idcl>tcp				return crTCP;
 <idcl>type				return crTYPE;
 <idcl>linemode			return crLINEMODE;
-<idcl>syslog		    return crSYSLOGMODE;
+<idcl>syslog			return crSYSLOGMODE;
 <idcl>transport			return crTRANSPORT;
 <idcl>gzip				return crGZIP;
 <idcl>lz4				return crLZ4;

--- a/conffile.l
+++ b/conffile.l
@@ -81,6 +81,7 @@ cluster				{
 <idcl>tcp				return crTCP;
 <idcl>type				return crTYPE;
 <idcl>linemode			return crLINEMODE;
+<idcl>syslog		    return crSYSLOGMODE;
 <idcl>transport			return crTRANSPORT;
 <idcl>gzip				return crGZIP;
 <idcl>lz4				return crLZ4;

--- a/conffile.tab.c
+++ b/conffile.tab.c
@@ -130,6 +130,7 @@ struct _clhost {
 	int port;
 	char *inst;
 	int proto;
+	con_type type;
 	con_trnsp trnsp;
 	void *saddr;
 	void *hint;
@@ -163,7 +164,7 @@ struct _rcptr_trsp {
 	char *pemcert;
 };
 
-#line 167 "conffile.tab.c" /* yacc.c:355  */
+#line 168 "conffile.tab.c" /* yacc.c:355  */
 
 /* Token type.  */
 #ifndef ROUTER_YYTOKENTYPE
@@ -230,16 +231,17 @@ struct _rcptr_trsp {
     crLISTEN = 315,
     crTYPE = 316,
     crLINEMODE = 317,
-    crTRANSPORT = 318,
-    crGZIP = 319,
-    crLZ4 = 320,
-    crSSL = 321,
-    crUNIX = 322,
-    crINCLUDE = 323,
-    crCOMMENT = 324,
-    crSTRING = 325,
-    crUNEXPECTED = 326,
-    crINTVAL = 327
+    crSYSLOGMODE = 318,
+    crTRANSPORT = 319,
+    crGZIP = 320,
+    crLZ4 = 321,
+    crSSL = 322,
+    crUNIX = 323,
+    crINCLUDE = 324,
+    crCOMMENT = 325,
+    crSTRING = 326,
+    crUNEXPECTED = 327,
+    crINTVAL = 328
   };
 #endif
 
@@ -271,6 +273,8 @@ union ROUTER_YYSTYPE
   con_proto rcptr_proto;
   /* cluster_opt_transport  */
   con_trnsp cluster_opt_transport;
+  /* cluster_opt_type  */
+  con_type cluster_opt_type;
   /* match_opt_send_to  */
   destinations * match_opt_send_to;
   /* match_send_to  */
@@ -351,7 +355,7 @@ union ROUTER_YYSTYPE
   struct _rcptr * receptor;
   /* transport_mode  */
   struct _rcptr_trsp * transport_mode;
-#line 355 "conffile.tab.c" /* yacc.c:355  */
+#line 359 "conffile.tab.c" /* yacc.c:355  */
 };
 
 typedef union ROUTER_YYSTYPE ROUTER_YYSTYPE;
@@ -381,7 +385,7 @@ int router_yyparse (void *yyscanner, router *rtr, allocator *ralloc, allocator *
 
 /* Copy the second part of user declarations.  */
 
-#line 385 "conffile.tab.c" /* yacc.c:358  */
+#line 389 "conffile.tab.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -628,18 +632,18 @@ union yyalloc
 #define YYLAST   126
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  76
+#define YYNTOKENS  77
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  59
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  117
+#define YYNRULES  118
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  180
+#define YYNSTATES  181
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   327
+#define YYMAXUTOK   328
 
 #define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -652,9 +656,9 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,    75,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,     2,     2,     2,     2,     2,    73,
-       2,    74,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,    76,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,    74,
+       2,    75,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -680,25 +684,25 @@ static const yytype_uint8 yytranslate[] =
       35,    36,    37,    38,    39,    40,    41,    42,    43,    44,
       45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
       55,    56,    57,    58,    59,    60,    61,    62,    63,    64,
-      65,    66,    67,    68,    69,    70,    71,    72
+      65,    66,    67,    68,    69,    70,    71,    72,    73
 };
 
 #if ROUTER_YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   120,   120,   123,   124,   127,   130,   131,   132,   133,
-     134,   135,   136,   137,   141,   208,   249,   251,   255,   256,
-     257,   260,   261,   264,   265,   266,   269,   270,   273,   274,
-     277,   279,   280,   282,   302,   304,   305,   307,   328,   329,
-     330,   340,   341,   342,   345,   346,   349,   350,   360,   370,
-     384,   439,   451,   454,   456,   457,   460,   479,   480,   499,
-     500,   503,   504,   507,   508,   511,   514,   524,   527,   529,
-     530,   533,   549,   550,   555,   600,   691,   692,   697,   698,
-     699,   702,   706,   707,   709,   724,   725,   726,   727,   728,
-     729,   730,   740,   741,   744,   745,   750,   765,   790,   791,
-     802,   803,   806,   807,   812,   830,   854,   863,   879,   895,
-     914,   917,   918,   921,   958,   980,   981,   986
+       0,   122,   122,   125,   126,   129,   132,   133,   134,   135,
+     136,   137,   138,   139,   143,   210,   251,   253,   257,   258,
+     259,   262,   263,   266,   267,   268,   271,   272,   275,   276,
+     279,   281,   282,   284,   304,   306,   307,   309,   331,   332,
+     333,   343,   344,   345,   348,   349,   350,   353,   354,   364,
+     374,   388,   443,   455,   458,   460,   461,   464,   483,   484,
+     503,   504,   507,   508,   511,   512,   515,   518,   528,   531,
+     533,   534,   537,   553,   554,   559,   604,   695,   696,   701,
+     702,   703,   706,   710,   711,   713,   728,   729,   730,   731,
+     732,   733,   734,   744,   745,   748,   749,   754,   769,   794,
+     795,   806,   807,   810,   811,   816,   834,   858,   867,   883,
+     899,   918,   921,   922,   925,   962,   984,   985,   990
 };
 #endif
 
@@ -718,15 +722,15 @@ static const char *const yytname[] =
   "crAVERAGE", "crMEDIAN", "crVARIANCE", "crSTDDEV", "crPERCENTILE",
   "crWRITE", "crSTATISTICS", "crSUBMIT", "crRESET", "crCOUNTERS",
   "crINTERVAL", "crPREFIX", "crWITH", "crLISTEN", "crTYPE", "crLINEMODE",
-  "crTRANSPORT", "crGZIP", "crLZ4", "crSSL", "crUNIX", "crINCLUDE",
-  "crCOMMENT", "crSTRING", "crUNEXPECTED", "crINTVAL", "';'", "'='", "'*'",
-  "$accept", "stmts", "opt_stmt", "stmt", "command", "cluster",
-  "cluster_type", "cluster_useall", "cluster_opt_useall", "cluster_ch",
-  "cluster_opt_repl", "cluster_file", "cluster_paths", "cluster_opt_path",
-  "cluster_path", "cluster_hosts", "cluster_opt_host", "cluster_host",
-  "cluster_opt_instance", "cluster_opt_proto", "cluster_opt_type",
-  "cluster_opt_transport", "match", "match_exprs", "match_exprs2",
-  "match_opt_expr", "match_expr", "match_opt_validate",
+  "crSYSLOGMODE", "crTRANSPORT", "crGZIP", "crLZ4", "crSSL", "crUNIX",
+  "crINCLUDE", "crCOMMENT", "crSTRING", "crUNEXPECTED", "crINTVAL", "';'",
+  "'='", "'*'", "$accept", "stmts", "opt_stmt", "stmt", "command",
+  "cluster", "cluster_type", "cluster_useall", "cluster_opt_useall",
+  "cluster_ch", "cluster_opt_repl", "cluster_file", "cluster_paths",
+  "cluster_opt_path", "cluster_path", "cluster_hosts", "cluster_opt_host",
+  "cluster_host", "cluster_opt_instance", "cluster_opt_proto",
+  "cluster_opt_type", "cluster_opt_transport", "match", "match_exprs",
+  "match_exprs2", "match_opt_expr", "match_expr", "match_opt_validate",
   "match_log_or_drop", "match_opt_route", "match_opt_send_to",
   "match_send_to", "match_dsts", "match_dsts2", "match_opt_dst",
   "match_dst", "match_opt_stop", "rewrite", "aggregate",
@@ -751,7 +755,7 @@ static const yytype_uint16 yytoknum[] =
      295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
      305,   306,   307,   308,   309,   310,   311,   312,   313,   314,
      315,   316,   317,   318,   319,   320,   321,   322,   323,   324,
-     325,   326,   327,    59,    61,    42
+     325,   326,   327,   328,    59,    61,    42
 };
 # endif
 
@@ -769,24 +773,25 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int8 yypact[] =
 {
-      -2,   -50,   -65,   -28,   -23,   -20,    -5,    -9,   -17,    55,
-     -98,    -2,   -16,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
-     -98,    34,   -98,   -98,    38,   -98,   -20,    35,    32,    28,
-      31,     8,     2,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
-     -98,   -98,   -98,   -98,    54,    -3,    56,    57,     5,     6,
-      46,   -98,   -98,   -22,     7,    -1,     0,    17,    20,    16,
-     -98,     9,   -98,    -3,   -98,   -98,    10,   -98,   -98,   -98,
-       5,    61,    58,    60,   -98,   -98,    59,   -98,    15,   -98,
-      62,    63,    53,    29,    60,   -57,    19,   -51,    77,   -98,
-     -98,   -98,   -98,   -98,     3,    21,    67,    59,   -98,   -98,
-     -98,   -98,   -98,    64,   -98,    36,    26,   -98,    59,   -98,
-     -98,    33,    85,   -98,    19,   -98,   -98,    30,    39,   -98,
-     -98,   -98,   -98,   -22,   -98,    65,   -98,   -98,   -98,   -98,
-     -13,   -98,   -98,   -98,   -98,    40,    41,   -98,    37,   -98,
-     -98,   -98,   -98,   -98,   -52,   -98,    69,   -98,   -98,   -98,
-      70,    71,    66,   -21,   -14,    60,    66,   -98,   -98,   -98,
-      72,   -98,   -98,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
-      68,    59,   -98,   -98,    73,    81,   -98,   -98,    43,   -98
+      -2,   -51,   -66,   -28,   -19,   -18,    -4,    -7,   -12,    56,
+     -98,    -2,   -17,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
+     -98,    34,   -98,   -98,    42,   -98,   -18,    36,    33,    32,
+      35,     9,     6,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
+     -98,   -98,   -98,   -98,    54,    -1,    55,    59,     2,     5,
+      50,   -98,   -98,   -22,     7,     4,     8,    18,    21,    16,
+     -98,    10,   -98,    -1,   -98,   -98,    11,   -98,   -98,   -98,
+       2,    63,    60,    62,   -98,   -98,    61,   -98,    19,   -98,
+      57,    64,    53,    38,    62,   -58,    20,   -52,    79,   -98,
+     -98,   -98,   -98,   -98,     3,    22,    69,    61,   -98,   -98,
+     -98,   -98,   -98,    65,   -98,    43,    24,   -98,    61,   -98,
+     -98,    28,    88,   -98,    20,   -98,   -98,    30,    41,   -98,
+     -98,   -98,   -98,   -22,   -98,    70,   -98,   -98,   -98,   -98,
+     -13,   -98,   -98,   -98,   -98,   -15,    39,   -98,    37,   -98,
+     -98,   -98,   -98,   -98,   -98,   -53,   -98,    73,   -98,   -98,
+     -98,    71,    72,    67,   -21,   -14,    62,    67,   -98,   -98,
+     -98,    74,   -98,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
+     -98,    66,    61,   -98,   -98,    75,    82,   -98,   -98,    40,
+     -98
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -794,33 +799,34 @@ static const yytype_int8 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       3,     0,     0,     0,     0,     0,    98,     0,     0,     0,
+       3,     0,     0,     0,     0,     0,    99,     0,     0,     0,
        2,     3,     0,     6,     7,     8,     9,    10,    11,    12,
-      13,     0,    56,    51,    57,    52,    54,     0,     0,     0,
-       0,   100,     0,   104,   117,     1,     4,     5,    18,    19,
+      13,     0,    57,    52,    58,    53,    55,     0,     0,     0,
+       0,   101,     0,   105,   118,     1,     4,     5,    18,    19,
       20,    23,    24,    25,    29,     0,    21,    26,     0,     0,
-      61,    55,    53,     0,     0,     0,     0,     0,   102,   106,
+      62,    56,    54,     0,     0,     0,     0,     0,   103,   107,
       28,    38,    14,    35,    22,    16,     0,    17,    33,    15,
-      31,     0,     0,    63,    66,    71,    72,    67,    69,    74,
-       0,     0,     0,     0,    94,     0,     0,     0,    41,    36,
-      34,    27,    30,    32,     0,     0,     0,    72,    64,    73,
-      96,    70,    68,     0,    99,     0,     0,    95,    72,   107,
-     108,     0,     0,   105,   111,    39,    40,     0,    44,    59,
-      60,    58,    62,     0,    50,     0,   101,   103,    97,   109,
-       0,   112,   110,    42,    43,     0,    46,    65,     0,   116,
-     115,   114,   113,    45,     0,    37,     0,    47,    48,    49,
-      76,     0,     0,     0,     0,    94,    82,    78,    79,    80,
-       0,    85,    86,    87,    88,    89,    90,    92,    93,    91,
-       0,    72,    83,    81,     0,     0,    75,    77,     0,    84
+      31,     0,     0,    64,    67,    72,    73,    68,    70,    75,
+       0,     0,     0,     0,    95,     0,     0,     0,    41,    36,
+      34,    27,    30,    32,     0,     0,     0,    73,    65,    74,
+      97,    71,    69,     0,   100,     0,     0,    96,    73,   108,
+     109,     0,     0,   106,   112,    39,    40,     0,    44,    60,
+      61,    59,    63,     0,    51,     0,   102,   104,    98,   110,
+       0,   113,   111,    42,    43,     0,    47,    66,     0,   117,
+     116,   115,   114,    45,    46,     0,    37,     0,    48,    49,
+      50,    77,     0,     0,     0,     0,    95,    83,    79,    80,
+      81,     0,    86,    87,    88,    89,    90,    91,    93,    94,
+      92,     0,    73,    84,    82,     0,     0,    76,    78,     0,
+      85
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -98,   -98,    99,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
-     -98,   -98,   -98,   -98,    45,    48,   -98,   -98,   -98,   -98,
+     -98,   -98,   101,   -98,   -98,   -98,   -98,   -98,   -98,   -98,
+     -98,   -98,   -98,   -98,    45,    58,   -98,   -98,   -98,   -98,
      -98,   -98,   -98,   -98,     1,   -98,   -98,   -98,   -98,   -98,
-     -98,    44,    -7,    47,   -98,   -98,   -97,   -98,   -98,   -98,
+     -98,    44,   -10,    46,   -98,   -98,   -97,   -98,   -98,   -98,
      -98,   -38,   -98,   -98,   -98,   -36,   -98,   -98,   -98,   -98,
      -98,   -98,   -98,   -98,    12,   -98,   -98,   -98,   -98
 };
@@ -830,9 +836,9 @@ static const yytype_int16 yydefgoto[] =
 {
       -1,     9,    10,    11,    12,    13,    45,    46,    65,    47,
       67,    48,    69,    92,    70,    62,    90,    63,    88,   118,
-     136,   145,    14,    24,    25,    52,    26,    50,   121,    73,
-      97,   107,    76,    77,   102,    78,   100,    15,    16,   152,
-     160,   155,   173,   156,   170,   108,    17,    18,    31,    58,
+     136,   146,    14,    24,    25,    52,    26,    50,   121,    73,
+      97,   107,    76,    77,   102,    78,   100,    15,    16,   153,
+     161,   156,   174,   157,   171,   108,    17,    18,    31,    58,
       84,    19,    33,    86,   113,   132,   114,   142,    20
 };
 
@@ -842,76 +848,77 @@ static const yytype_int16 yydefgoto[] =
 static const yytype_uint8 yytable[] =
 {
      124,     1,   139,   140,    74,    22,    29,   109,   110,   111,
-      23,   128,   147,   148,   149,     2,   157,   158,   159,   115,
-      21,   116,     3,   119,   120,    27,     4,    51,     5,   161,
-     162,   163,   164,   165,   166,   167,   168,   169,    38,    39,
-      40,    41,    42,    43,    44,   133,   134,    28,    75,    30,
-      22,     6,    32,    34,   141,    35,    49,    37,     7,    55,
-      53,    54,    56,    57,    59,    60,     8,    61,    72,    66,
-      64,    80,    81,    82,   176,    68,    71,    79,    83,    85,
-      94,    95,    91,    87,    96,    75,    99,   105,   106,   112,
-     117,   122,   123,   126,   103,   104,   127,   125,   130,   138,
-     135,   150,   143,   129,   144,   151,   178,   153,   154,   146,
-      36,    89,   174,   179,   177,    93,   137,    98,   172,   171,
-     175,     0,     0,     0,     0,   101,   131
+      23,   128,   148,   149,   150,     2,   158,   159,   160,   115,
+      21,   116,     3,   119,   120,    27,     4,    51,     5,   162,
+     163,   164,   165,   166,   167,   168,   169,   170,    38,    39,
+      40,    41,    42,    43,    44,   133,   134,   143,   144,    75,
+      30,     6,    28,    22,    32,   141,    35,    37,     7,    34,
+      49,    53,    54,    55,    57,    60,    56,     8,    59,    64,
+      61,    66,    72,    68,    82,   177,    71,    80,    79,    83,
+      85,    81,    94,    95,    91,    87,    96,   105,    99,   103,
+      75,   112,   117,   122,   123,   127,   104,   106,   125,   129,
+     126,   130,   135,   145,   138,   151,   152,   179,   154,   155,
+     147,   180,    36,   137,   175,    93,   178,    98,   176,   173,
+     172,    89,     0,     0,   101,     0,   131
 };
 
 static const yytype_int16 yycheck[] =
 {
-      97,     3,    15,    16,    26,    70,     5,    64,    65,    66,
-      75,   108,    64,    65,    66,    17,    37,    38,    39,    70,
-      70,    72,    24,    20,    21,    53,    28,    26,    30,    43,
+      97,     3,    15,    16,    26,    71,     5,    65,    66,    67,
+      76,   108,    65,    66,    67,    17,    37,    38,    39,    71,
+      71,    73,    24,    20,    21,    53,    28,    26,    30,    43,
       44,    45,    46,    47,    48,    49,    50,    51,     4,     5,
-       6,     7,     8,     9,    10,    15,    16,    70,    70,    54,
-      70,    53,    61,    70,    67,     0,    18,    73,    60,    31,
-      25,    29,    31,    55,    62,    11,    68,    70,    22,    12,
-      14,    72,    72,    56,   171,    70,    70,    70,    58,    63,
-      19,    23,    72,    74,    24,    70,    27,    34,    59,    70,
-      13,    70,    25,    57,    32,    32,    70,    33,    13,    34,
-      61,    32,    62,    70,    63,    35,    25,    36,    42,    72,
-      11,    63,    40,    70,    41,    70,   123,    73,   156,   155,
-      52,    -1,    -1,    -1,    -1,    78,   114
+       6,     7,     8,     9,    10,    15,    16,    62,    63,    71,
+      54,    53,    71,    71,    61,    68,     0,    74,    60,    71,
+      18,    25,    29,    31,    55,    11,    31,    69,    62,    14,
+      71,    12,    22,    71,    56,   172,    71,    73,    71,    58,
+      64,    73,    19,    23,    73,    75,    24,    34,    27,    32,
+      71,    71,    13,    71,    25,    71,    32,    59,    33,    71,
+      57,    13,    61,    64,    34,    32,    35,    25,    36,    42,
+      73,    71,    11,   123,    40,    70,    41,    73,    52,   157,
+     156,    63,    -1,    -1,    78,    -1,   114
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,     3,    17,    24,    28,    30,    53,    60,    68,    77,
-      78,    79,    80,    81,    98,   113,   114,   122,   123,   127,
-     134,    70,    70,    75,    99,   100,   102,    53,    70,   100,
-      54,   124,    61,   128,    70,     0,    78,    73,     4,     5,
-       6,     7,     8,     9,    10,    82,    83,    85,    87,    18,
-     103,   100,   101,    25,    29,    31,    31,    55,   125,    62,
-      11,    70,    91,    93,    14,    84,    12,    86,    70,    88,
-      90,    70,    22,   105,    26,    70,   108,   109,   111,    70,
-      72,    72,    56,    58,   126,    63,   129,    74,    94,    91,
-      92,    72,    89,    90,    19,    23,    24,   106,   107,    27,
-     112,   109,   110,    32,    32,    34,    59,   107,   121,    64,
-      65,    66,    70,   130,   132,    70,    72,    13,    95,    20,
-      21,   104,    70,    25,   112,    33,    57,    70,   112,    70,
-      13,   130,   131,    15,    16,    61,    96,   108,    34,    15,
-      16,    67,   133,    62,    63,    97,    72,    64,    65,    66,
-      32,    35,   115,    36,    42,   117,   119,    37,    38,    39,
-     116,    43,    44,    45,    46,    47,    48,    49,    50,    51,
-     120,   121,   117,   118,    40,    52,   112,    41,    25,    70
+       0,     3,    17,    24,    28,    30,    53,    60,    69,    78,
+      79,    80,    81,    82,    99,   114,   115,   123,   124,   128,
+     135,    71,    71,    76,   100,   101,   103,    53,    71,   101,
+      54,   125,    61,   129,    71,     0,    79,    74,     4,     5,
+       6,     7,     8,     9,    10,    83,    84,    86,    88,    18,
+     104,   101,   102,    25,    29,    31,    31,    55,   126,    62,
+      11,    71,    92,    94,    14,    85,    12,    87,    71,    89,
+      91,    71,    22,   106,    26,    71,   109,   110,   112,    71,
+      73,    73,    56,    58,   127,    64,   130,    75,    95,    92,
+      93,    73,    90,    91,    19,    23,    24,   107,   108,    27,
+     113,   110,   111,    32,    32,    34,    59,   108,   122,    65,
+      66,    67,    71,   131,   133,    71,    73,    13,    96,    20,
+      21,   105,    71,    25,   113,    33,    57,    71,   113,    71,
+      13,   131,   132,    15,    16,    61,    97,   109,    34,    15,
+      16,    68,   134,    62,    63,    64,    98,    73,    65,    66,
+      67,    32,    35,   116,    36,    42,   118,   120,    37,    38,
+      39,   117,    43,    44,    45,    46,    47,    48,    49,    50,
+      51,   121,   122,   118,   119,    40,    52,   113,    41,    25,
+      71
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    76,    77,    78,    78,    79,    80,    80,    80,    80,
-      80,    80,    80,    80,    81,    81,    82,    82,    83,    83,
-      83,    84,    84,    85,    85,    85,    86,    86,    87,    87,
-      88,    89,    89,    90,    91,    92,    92,    93,    94,    94,
-      94,    95,    95,    95,    96,    96,    97,    97,    97,    97,
-      98,    99,    99,   100,   101,   101,   102,   103,   103,   104,
-     104,   105,   105,   106,   106,   107,   108,   108,   109,   110,
-     110,   111,   112,   112,   113,   114,   115,   115,   116,   116,
-     116,   117,   118,   118,   119,   120,   120,   120,   120,   120,
-     120,   120,   120,   120,   121,   121,   122,   123,   124,   124,
-     125,   125,   126,   126,   127,   128,   129,   129,   129,   129,
-     130,   131,   131,   132,   132,   133,   133,   134
+       0,    77,    78,    79,    79,    80,    81,    81,    81,    81,
+      81,    81,    81,    81,    82,    82,    83,    83,    84,    84,
+      84,    85,    85,    86,    86,    86,    87,    87,    88,    88,
+      89,    90,    90,    91,    92,    93,    93,    94,    95,    95,
+      95,    96,    96,    96,    97,    97,    97,    98,    98,    98,
+      98,    99,   100,   100,   101,   102,   102,   103,   104,   104,
+     105,   105,   106,   106,   107,   107,   108,   109,   109,   110,
+     111,   111,   112,   113,   113,   114,   115,   116,   116,   117,
+     117,   117,   118,   119,   119,   120,   121,   121,   121,   121,
+     121,   121,   121,   121,   121,   122,   122,   123,   124,   125,
+     125,   126,   126,   127,   127,   128,   129,   130,   130,   130,
+     130,   131,   132,   132,   133,   133,   134,   134,   135
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
@@ -921,14 +928,14 @@ static const yytype_uint8 yyr2[] =
        1,     1,     1,     1,     4,     4,     2,     2,     1,     1,
        1,     0,     1,     1,     1,     1,     0,     2,     2,     1,
        2,     0,     1,     1,     2,     0,     1,     5,     0,     2,
-       2,     0,     2,     2,     0,     2,     0,     2,     2,     2,
-       6,     1,     1,     2,     0,     1,     1,     0,     4,     1,
-       1,     0,     3,     0,     1,     3,     1,     1,     2,     0,
-       1,     1,     0,     1,     4,    13,     0,     5,     1,     1,
-       1,     2,     0,     1,     5,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     0,     1,     5,     6,     0,     4,
-       0,     4,     0,     3,     2,     4,     0,     2,     2,     3,
-       2,     0,     1,     3,     3,     1,     1,     2
+       2,     0,     2,     2,     0,     2,     2,     0,     2,     2,
+       2,     6,     1,     1,     2,     0,     1,     1,     0,     4,
+       1,     1,     0,     3,     0,     1,     3,     1,     1,     2,
+       0,     1,     1,     0,     1,     4,    13,     0,     5,     1,
+       1,     1,     2,     0,     1,     5,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     0,     1,     5,     6,     0,
+       4,     0,     4,     0,     3,     2,     4,     0,     2,     2,
+       3,     2,     0,     1,     3,     3,     1,     1,     2
 };
 
 
@@ -1712,7 +1719,7 @@ yyreduce:
   switch (yyn)
     {
         case 14:
-#line 142 "conffile.y" /* yacc.c:1646  */
+#line 144 "conffile.y" /* yacc.c:1661  */
     {
 	   	struct _clhost *w;
 		char *err;
@@ -1765,7 +1772,7 @@ yyreduce:
 		
 		for (w = (*(struct _clhost **)(&yyvsp[0])); w != NULL; w = w->next) {
 			err = router_add_server(rtr, w->ip, w->port, w->inst,
-					T_LINEMODE, w->trnsp, w->proto,
+					w->type, w->trnsp, w->proto,
 					w->saddr, w->hint, (*(struct _clust*)(&yyvsp[-1])).ival, (*(cluster **)(&yyval)));
 			if (err != NULL) {
 				router_yyerror(&yylloc, yyscanner, rtr, ralloc, palloc, err);
@@ -1779,11 +1786,11 @@ yyreduce:
 			YYERROR;
 		}
 	   }
-#line 1783 "conffile.tab.c" /* yacc.c:1646  */
+#line 1790 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 15:
-#line 209 "conffile.y" /* yacc.c:1646  */
+#line 211 "conffile.y" /* yacc.c:1661  */
     {
 	   	struct _clhost *w;
 		char *err;
@@ -1821,113 +1828,113 @@ yyreduce:
 			YYERROR;
 		}
 	   }
-#line 1825 "conffile.tab.c" /* yacc.c:1646  */
+#line 1832 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 16:
-#line 250 "conffile.y" /* yacc.c:1646  */
+#line 252 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clust*)(&yyval)).t = (*(enum clusttype*)(&yyvsp[-1])); (*(struct _clust*)(&yyval)).ival = (*(int*)(&yyvsp[0])); }
-#line 1831 "conffile.tab.c" /* yacc.c:1646  */
+#line 1838 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 17:
-#line 252 "conffile.y" /* yacc.c:1646  */
+#line 254 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clust*)(&yyval)).t = (*(enum clusttype*)(&yyvsp[-1])); (*(struct _clust*)(&yyval)).ival = (*(int*)(&yyvsp[0])); }
-#line 1837 "conffile.tab.c" /* yacc.c:1646  */
+#line 1844 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 18:
-#line 255 "conffile.y" /* yacc.c:1646  */
+#line 257 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = FORWARD; }
-#line 1843 "conffile.tab.c" /* yacc.c:1646  */
+#line 1850 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 19:
-#line 256 "conffile.y" /* yacc.c:1646  */
+#line 258 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = ANYOF; }
-#line 1849 "conffile.tab.c" /* yacc.c:1646  */
+#line 1856 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 20:
-#line 257 "conffile.y" /* yacc.c:1646  */
+#line 259 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = FAILOVER; }
-#line 1855 "conffile.tab.c" /* yacc.c:1646  */
+#line 1862 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 21:
-#line 260 "conffile.y" /* yacc.c:1646  */
+#line 262 "conffile.y" /* yacc.c:1661  */
     { (*(int*)(&yyval)) = 0; }
-#line 1861 "conffile.tab.c" /* yacc.c:1646  */
+#line 1868 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 22:
-#line 261 "conffile.y" /* yacc.c:1646  */
+#line 263 "conffile.y" /* yacc.c:1661  */
     { (*(int*)(&yyval)) = 1; }
-#line 1867 "conffile.tab.c" /* yacc.c:1646  */
+#line 1874 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 23:
-#line 264 "conffile.y" /* yacc.c:1646  */
+#line 266 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = CARBON_CH; }
-#line 1873 "conffile.tab.c" /* yacc.c:1646  */
+#line 1880 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 24:
-#line 265 "conffile.y" /* yacc.c:1646  */
+#line 267 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = FNV1A_CH; }
-#line 1879 "conffile.tab.c" /* yacc.c:1646  */
+#line 1886 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 25:
-#line 266 "conffile.y" /* yacc.c:1646  */
+#line 268 "conffile.y" /* yacc.c:1661  */
     { (*(enum clusttype*)(&yyval)) = JUMP_CH; }
-#line 1885 "conffile.tab.c" /* yacc.c:1646  */
+#line 1892 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 26:
-#line 269 "conffile.y" /* yacc.c:1646  */
+#line 271 "conffile.y" /* yacc.c:1661  */
     { (*(int*)(&yyval)) = 1; }
-#line 1891 "conffile.tab.c" /* yacc.c:1646  */
+#line 1898 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 27:
-#line 270 "conffile.y" /* yacc.c:1646  */
+#line 272 "conffile.y" /* yacc.c:1661  */
     { (*(int*)(&yyval)) = (*(int*)(&yyvsp[0])); }
-#line 1897 "conffile.tab.c" /* yacc.c:1646  */
+#line 1904 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 28:
-#line 273 "conffile.y" /* yacc.c:1646  */
+#line 275 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clust*)(&yyval)).t = FILELOGIP; (*(struct _clust*)(&yyval)).ival = 0; }
-#line 1903 "conffile.tab.c" /* yacc.c:1646  */
+#line 1910 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 29:
-#line 274 "conffile.y" /* yacc.c:1646  */
+#line 276 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clust*)(&yyval)).t = FILELOG; (*(struct _clust*)(&yyval)).ival = 0; }
-#line 1909 "conffile.tab.c" /* yacc.c:1646  */
+#line 1916 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 30:
-#line 277 "conffile.y" /* yacc.c:1646  */
+#line 279 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyvsp[-1]))->next = (*(struct _clhost **)(&yyvsp[0])); (*(struct _clhost **)(&yyval)) = (*(struct _clhost **)(&yyvsp[-1])); }
-#line 1915 "conffile.tab.c" /* yacc.c:1646  */
+#line 1922 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 31:
-#line 279 "conffile.y" /* yacc.c:1646  */
+#line 281 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyval)) = NULL; }
-#line 1921 "conffile.tab.c" /* yacc.c:1646  */
+#line 1928 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 32:
-#line 280 "conffile.y" /* yacc.c:1646  */
+#line 282 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyval)) = (*(struct _clhost **)(&yyvsp[0])); }
-#line 1927 "conffile.tab.c" /* yacc.c:1646  */
+#line 1934 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 33:
-#line 283 "conffile.y" /* yacc.c:1646  */
+#line 285 "conffile.y" /* yacc.c:1661  */
     {
 				struct _clhost *ret = ra_malloc(palloc, sizeof(struct _clhost));
 				char *err = router_validate_path(rtr, (*(char **)(&yyvsp[0])));
@@ -1945,29 +1952,29 @@ yyreduce:
 				ret->next = NULL;
 				(*(struct _clhost **)(&yyval)) = ret;
 			}
-#line 1949 "conffile.tab.c" /* yacc.c:1646  */
+#line 1956 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 34:
-#line 302 "conffile.y" /* yacc.c:1646  */
+#line 304 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyvsp[-1]))->next = (*(struct _clhost **)(&yyvsp[0])); (*(struct _clhost **)(&yyval)) = (*(struct _clhost **)(&yyvsp[-1])); }
-#line 1955 "conffile.tab.c" /* yacc.c:1646  */
+#line 1962 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 35:
-#line 304 "conffile.y" /* yacc.c:1646  */
+#line 306 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyval)) = NULL; }
-#line 1961 "conffile.tab.c" /* yacc.c:1646  */
+#line 1968 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 36:
-#line 305 "conffile.y" /* yacc.c:1646  */
+#line 307 "conffile.y" /* yacc.c:1661  */
     { (*(struct _clhost **)(&yyval)) = (*(struct _clhost **)(&yyvsp[0])); }
-#line 1967 "conffile.tab.c" /* yacc.c:1646  */
+#line 1974 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 37:
-#line 310 "conffile.y" /* yacc.c:1646  */
+#line 312 "conffile.y" /* yacc.c:1661  */
     {
 			  	struct _clhost *ret = ra_malloc(palloc, sizeof(struct _clhost));
 				char *err = router_validate_address(
@@ -1981,27 +1988,28 @@ yyreduce:
 				}
 				ret->inst = (*(char **)(&yyvsp[-3]));
 				ret->proto = (*(con_proto*)(&yyvsp[-2]));
+				ret->type = (*(con_type*)(&yyvsp[-1]));
 				ret->trnsp = (*(con_trnsp*)(&yyvsp[0]));
 				ret->next = NULL;
 				(*(struct _clhost **)(&yyval)) = ret;
 			  }
-#line 1989 "conffile.tab.c" /* yacc.c:1646  */
+#line 1997 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 38:
-#line 328 "conffile.y" /* yacc.c:1646  */
+#line 331 "conffile.y" /* yacc.c:1661  */
     { (*(char **)(&yyval)) = NULL; }
-#line 1995 "conffile.tab.c" /* yacc.c:1646  */
+#line 2003 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 39:
-#line 329 "conffile.y" /* yacc.c:1646  */
+#line 332 "conffile.y" /* yacc.c:1661  */
     { (*(char **)(&yyval)) = (*(char **)(&yyvsp[0])); }
-#line 2001 "conffile.tab.c" /* yacc.c:1646  */
+#line 2009 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 40:
-#line 331 "conffile.y" /* yacc.c:1646  */
+#line 334 "conffile.y" /* yacc.c:1661  */
     {
 						(*(char **)(&yyval)) = ra_malloc(palloc, sizeof(char) * 12);
 						if ((*(char **)(&yyval)) == NULL) {
@@ -2010,35 +2018,53 @@ yyreduce:
 						}
 						snprintf((*(char **)(&yyval)), 12, "%d", (*(int*)(&yyvsp[0])));
 					}
-#line 2014 "conffile.tab.c" /* yacc.c:1646  */
+#line 2022 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 41:
-#line 340 "conffile.y" /* yacc.c:1646  */
+#line 343 "conffile.y" /* yacc.c:1661  */
     { (*(con_proto*)(&yyval)) = CON_TCP; }
-#line 2020 "conffile.tab.c" /* yacc.c:1646  */
+#line 2028 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 42:
-#line 341 "conffile.y" /* yacc.c:1646  */
+#line 344 "conffile.y" /* yacc.c:1661  */
     { (*(con_proto*)(&yyval)) = CON_UDP; }
-#line 2026 "conffile.tab.c" /* yacc.c:1646  */
+#line 2034 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 43:
-#line 342 "conffile.y" /* yacc.c:1646  */
+#line 345 "conffile.y" /* yacc.c:1661  */
     { (*(con_proto*)(&yyval)) = CON_TCP; }
-#line 2032 "conffile.tab.c" /* yacc.c:1646  */
+#line 2040 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 44:
+#line 348 "conffile.y" /* yacc.c:1661  */
+    { (*(con_type*)(&yyval)) = T_LINEMODE; }
+#line 2046 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 45:
+#line 349 "conffile.y" /* yacc.c:1661  */
+    { (*(con_type*)(&yyval)) = T_LINEMODE; }
+#line 2052 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 46:
-#line 349 "conffile.y" /* yacc.c:1646  */
-    { (*(con_trnsp*)(&yyval)) = W_PLAIN; }
-#line 2038 "conffile.tab.c" /* yacc.c:1646  */
+#line 350 "conffile.y" /* yacc.c:1661  */
+    { (*(con_type*)(&yyval)) = T_SYSLOGMODE; }
+#line 2058 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 47:
-#line 350 "conffile.y" /* yacc.c:1646  */
+#line 353 "conffile.y" /* yacc.c:1661  */
+    { (*(con_trnsp*)(&yyval)) = W_PLAIN; }
+#line 2064 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 48:
+#line 354 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_GZIP
 							(*(con_trnsp*)(&yyval)) = W_GZIP;
@@ -2049,11 +2075,11 @@ yyreduce:
 							YYERROR;
 #endif
 					 }
-#line 2053 "conffile.tab.c" /* yacc.c:1646  */
+#line 2079 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 48:
-#line 360 "conffile.y" /* yacc.c:1646  */
+  case 49:
+#line 364 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_LZ4
 							(*(con_trnsp*)(&yyval)) = W_LZ4;
@@ -2064,11 +2090,11 @@ yyreduce:
 							YYERROR;
 #endif
 					 }
-#line 2068 "conffile.tab.c" /* yacc.c:1646  */
+#line 2094 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 49:
-#line 370 "conffile.y" /* yacc.c:1646  */
+  case 50:
+#line 374 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_SSL
 							(*(con_trnsp*)(&yyval)) = W_SSL;
@@ -2079,11 +2105,11 @@ yyreduce:
 							YYERROR;
 #endif
 					 }
-#line 2083 "conffile.tab.c" /* yacc.c:1646  */
+#line 2109 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 50:
-#line 386 "conffile.y" /* yacc.c:1646  */
+  case 51:
+#line 390 "conffile.y" /* yacc.c:1661  */
     {
 	 	/* each expr comes with an allocated route, populate it */
 		struct _maexpr *we;
@@ -2135,11 +2161,11 @@ yyreduce:
 			}
 		}
 	 }
-#line 2139 "conffile.tab.c" /* yacc.c:1646  */
+#line 2165 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 51:
-#line 440 "conffile.y" /* yacc.c:1646  */
+  case 52:
+#line 444 "conffile.y" /* yacc.c:1661  */
     {
 			if (((*(struct _maexpr **)(&yyval)) = ra_malloc(palloc, sizeof(struct _maexpr))) == NULL) {
 				logerr("out of memory\n");
@@ -2151,35 +2177,35 @@ yyreduce:
 			(*(struct _maexpr **)(&yyval))->drop = 0;
 			(*(struct _maexpr **)(&yyval))->next = NULL;
 		   }
-#line 2155 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 52:
-#line 451 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[0])); }
-#line 2161 "conffile.tab.c" /* yacc.c:1646  */
+#line 2181 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 53:
-#line 454 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _maexpr **)(&yyvsp[-1]))->next = (*(struct _maexpr **)(&yyvsp[0])); (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[-1])); }
-#line 2167 "conffile.tab.c" /* yacc.c:1646  */
+#line 455 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[0])); }
+#line 2187 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 54:
-#line 456 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _maexpr **)(&yyval)) = NULL; }
-#line 2173 "conffile.tab.c" /* yacc.c:1646  */
+#line 458 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _maexpr **)(&yyvsp[-1]))->next = (*(struct _maexpr **)(&yyvsp[0])); (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[-1])); }
+#line 2193 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 55:
-#line 457 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[0])); }
-#line 2179 "conffile.tab.c" /* yacc.c:1646  */
+#line 460 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _maexpr **)(&yyval)) = NULL; }
+#line 2199 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 56:
-#line 461 "conffile.y" /* yacc.c:1646  */
+#line 461 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _maexpr **)(&yyval)) = (*(struct _maexpr **)(&yyvsp[0])); }
+#line 2205 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 57:
+#line 465 "conffile.y" /* yacc.c:1661  */
     {
 			char *err;
 			if (((*(struct _maexpr **)(&yyval)) = ra_malloc(palloc, sizeof(struct _maexpr))) == NULL) {
@@ -2196,17 +2222,17 @@ yyreduce:
 			(*(struct _maexpr **)(&yyval))->drop = 0;
 			(*(struct _maexpr **)(&yyval))->next = NULL;
 		  }
-#line 2200 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 57:
-#line 479 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _maexpr **)(&yyval)) = NULL; }
-#line 2206 "conffile.tab.c" /* yacc.c:1646  */
+#line 2226 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 58:
-#line 481 "conffile.y" /* yacc.c:1646  */
+#line 483 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _maexpr **)(&yyval)) = NULL; }
+#line 2232 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 59:
+#line 485 "conffile.y" /* yacc.c:1661  */
     {
 					char *err;
 					if (((*(struct _maexpr **)(&yyval)) = ra_malloc(palloc, sizeof(struct _maexpr))) == NULL) {
@@ -2223,53 +2249,53 @@ yyreduce:
 					(*(struct _maexpr **)(&yyval))->drop = (*(int*)(&yyvsp[0]));
 					(*(struct _maexpr **)(&yyval))->next = NULL;
 				  }
-#line 2227 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 59:
-#line 499 "conffile.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = 0; }
-#line 2233 "conffile.tab.c" /* yacc.c:1646  */
+#line 2253 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 60:
-#line 500 "conffile.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = 1; }
-#line 2239 "conffile.tab.c" /* yacc.c:1646  */
+#line 503 "conffile.y" /* yacc.c:1661  */
+    { (*(int*)(&yyval)) = 0; }
+#line 2259 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 61:
-#line 503 "conffile.y" /* yacc.c:1646  */
-    { (*(char **)(&yyval)) = NULL; }
-#line 2245 "conffile.tab.c" /* yacc.c:1646  */
+#line 504 "conffile.y" /* yacc.c:1661  */
+    { (*(int*)(&yyval)) = 1; }
+#line 2265 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 62:
-#line 504 "conffile.y" /* yacc.c:1646  */
-    { (*(char **)(&yyval)) = (*(char **)(&yyvsp[0])); }
-#line 2251 "conffile.tab.c" /* yacc.c:1646  */
+#line 507 "conffile.y" /* yacc.c:1661  */
+    { (*(char **)(&yyval)) = NULL; }
+#line 2271 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 63:
-#line 507 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = NULL; }
-#line 2257 "conffile.tab.c" /* yacc.c:1646  */
+#line 508 "conffile.y" /* yacc.c:1661  */
+    { (*(char **)(&yyval)) = (*(char **)(&yyvsp[0])); }
+#line 2277 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 64:
-#line 508 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
-#line 2263 "conffile.tab.c" /* yacc.c:1646  */
+#line 511 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = NULL; }
+#line 2283 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 65:
-#line 511 "conffile.y" /* yacc.c:1646  */
+#line 512 "conffile.y" /* yacc.c:1661  */
     { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
-#line 2269 "conffile.tab.c" /* yacc.c:1646  */
+#line 2289 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 66:
-#line 515 "conffile.y" /* yacc.c:1646  */
+#line 515 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
+#line 2295 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 67:
+#line 519 "conffile.y" /* yacc.c:1661  */
     {
 			if (((*(destinations **)(&yyval)) = ra_malloc(ralloc, sizeof(destinations))) == NULL) {
 				logerr("out of memory\n");
@@ -2279,35 +2305,35 @@ yyreduce:
 				YYABORT;
 			(*(destinations **)(&yyval))->next = NULL;
 		  }
-#line 2283 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 67:
-#line 524 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
-#line 2289 "conffile.tab.c" /* yacc.c:1646  */
+#line 2309 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 68:
-#line 527 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyvsp[-1]))->next = (*(destinations **)(&yyvsp[0])); (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[-1])); }
-#line 2295 "conffile.tab.c" /* yacc.c:1646  */
+#line 528 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
+#line 2315 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 69:
-#line 529 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = NULL; }
-#line 2301 "conffile.tab.c" /* yacc.c:1646  */
+#line 531 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyvsp[-1]))->next = (*(destinations **)(&yyvsp[0])); (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[-1])); }
+#line 2321 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 70:
-#line 530 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
-#line 2307 "conffile.tab.c" /* yacc.c:1646  */
+#line 533 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = NULL; }
+#line 2327 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 71:
-#line 534 "conffile.y" /* yacc.c:1646  */
+#line 534 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
+#line 2333 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 72:
+#line 538 "conffile.y" /* yacc.c:1661  */
     {
 			char *err;
 			if (((*(destinations **)(&yyval)) = ra_malloc(ralloc, sizeof(destinations))) == NULL) {
@@ -2321,23 +2347,23 @@ yyreduce:
 			}
 			(*(destinations **)(&yyval))->next = NULL;
 		 }
-#line 2325 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 72:
-#line 549 "conffile.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = 0; }
-#line 2331 "conffile.tab.c" /* yacc.c:1646  */
+#line 2351 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 73:
-#line 550 "conffile.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = 1; }
-#line 2337 "conffile.tab.c" /* yacc.c:1646  */
+#line 553 "conffile.y" /* yacc.c:1661  */
+    { (*(int*)(&yyval)) = 0; }
+#line 2357 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 74:
-#line 556 "conffile.y" /* yacc.c:1646  */
+#line 554 "conffile.y" /* yacc.c:1661  */
+    { (*(int*)(&yyval)) = 1; }
+#line 2363 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 75:
+#line 560 "conffile.y" /* yacc.c:1661  */
     {
 		char *err;
 		route *r = NULL;
@@ -2378,11 +2404,11 @@ yyreduce:
 			YYERROR;
 		}
 	   }
-#line 2382 "conffile.tab.c" /* yacc.c:1646  */
+#line 2408 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 75:
-#line 606 "conffile.y" /* yacc.c:1646  */
+  case 76:
+#line 610 "conffile.y" /* yacc.c:1661  */
     {
 		 	cluster *w;
 			aggregator *a;
@@ -2466,59 +2492,59 @@ yyreduce:
 			if ((*(destinations **)(&yyvsp[-1])) != NULL)
 				router_add_stubroute(rtr, AGGRSTUB, w, (*(destinations **)(&yyvsp[-1])));
 		 }
-#line 2470 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 76:
-#line 691 "conffile.y" /* yacc.c:1646  */
-    { (*(enum _aggr_timestamp*)(&yyval)) = TS_END; }
-#line 2476 "conffile.tab.c" /* yacc.c:1646  */
+#line 2496 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 77:
-#line 694 "conffile.y" /* yacc.c:1646  */
-    { (*(enum _aggr_timestamp*)(&yyval)) = (*(enum _aggr_timestamp*)(&yyvsp[-2])); }
-#line 2482 "conffile.tab.c" /* yacc.c:1646  */
+#line 695 "conffile.y" /* yacc.c:1661  */
+    { (*(enum _aggr_timestamp*)(&yyval)) = TS_END; }
+#line 2502 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 78:
-#line 697 "conffile.y" /* yacc.c:1646  */
-    { (*(enum _aggr_timestamp*)(&yyval)) = TS_START; }
-#line 2488 "conffile.tab.c" /* yacc.c:1646  */
+#line 698 "conffile.y" /* yacc.c:1661  */
+    { (*(enum _aggr_timestamp*)(&yyval)) = (*(enum _aggr_timestamp*)(&yyvsp[-2])); }
+#line 2508 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 79:
-#line 698 "conffile.y" /* yacc.c:1646  */
-    { (*(enum _aggr_timestamp*)(&yyval)) = TS_MIDDLE; }
-#line 2494 "conffile.tab.c" /* yacc.c:1646  */
+#line 701 "conffile.y" /* yacc.c:1661  */
+    { (*(enum _aggr_timestamp*)(&yyval)) = TS_START; }
+#line 2514 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 80:
-#line 699 "conffile.y" /* yacc.c:1646  */
-    { (*(enum _aggr_timestamp*)(&yyval)) = TS_END; }
-#line 2500 "conffile.tab.c" /* yacc.c:1646  */
+#line 702 "conffile.y" /* yacc.c:1661  */
+    { (*(enum _aggr_timestamp*)(&yyval)) = TS_MIDDLE; }
+#line 2520 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 81:
-#line 703 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp **)(&yyvsp[-1]))->next = (*(struct _agcomp **)(&yyvsp[0])); (*(struct _agcomp **)(&yyval)) = (*(struct _agcomp **)(&yyvsp[-1])); }
-#line 2506 "conffile.tab.c" /* yacc.c:1646  */
+#line 703 "conffile.y" /* yacc.c:1661  */
+    { (*(enum _aggr_timestamp*)(&yyval)) = TS_END; }
+#line 2526 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 82:
-#line 706 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp **)(&yyval)) = NULL; }
-#line 2512 "conffile.tab.c" /* yacc.c:1646  */
+#line 707 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp **)(&yyvsp[-1]))->next = (*(struct _agcomp **)(&yyvsp[0])); (*(struct _agcomp **)(&yyval)) = (*(struct _agcomp **)(&yyvsp[-1])); }
+#line 2532 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 83:
-#line 707 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp **)(&yyval)) = (*(struct _agcomp **)(&yyvsp[0])); }
-#line 2518 "conffile.tab.c" /* yacc.c:1646  */
+#line 710 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp **)(&yyval)) = NULL; }
+#line 2538 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 84:
-#line 711 "conffile.y" /* yacc.c:1646  */
+#line 711 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp **)(&yyval)) = (*(struct _agcomp **)(&yyvsp[0])); }
+#line 2544 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 85:
+#line 715 "conffile.y" /* yacc.c:1661  */
     {
 					(*(struct _agcomp **)(&yyval)) = ra_malloc(palloc, sizeof(struct _agcomp));
 					if ((*(struct _agcomp **)(&yyval)) == NULL) {
@@ -2530,47 +2556,47 @@ yyreduce:
 					(*(struct _agcomp **)(&yyval))->metric = (*(char **)(&yyvsp[0]));
 					(*(struct _agcomp **)(&yyval))->next = NULL;
 				 }
-#line 2534 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 85:
-#line 724 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = SUM; }
-#line 2540 "conffile.tab.c" /* yacc.c:1646  */
+#line 2560 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 86:
-#line 725 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = CNT; }
-#line 2546 "conffile.tab.c" /* yacc.c:1646  */
+#line 728 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = SUM; }
+#line 2566 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 87:
-#line 726 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = MAX; }
-#line 2552 "conffile.tab.c" /* yacc.c:1646  */
+#line 729 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = CNT; }
+#line 2572 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 88:
-#line 727 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = MIN; }
-#line 2558 "conffile.tab.c" /* yacc.c:1646  */
+#line 730 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = MAX; }
+#line 2578 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 89:
-#line 728 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = AVG; }
-#line 2564 "conffile.tab.c" /* yacc.c:1646  */
+#line 731 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = MIN; }
+#line 2584 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 90:
-#line 729 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = MEDN; }
-#line 2570 "conffile.tab.c" /* yacc.c:1646  */
+#line 732 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = AVG; }
+#line 2590 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 91:
-#line 731 "conffile.y" /* yacc.c:1646  */
+#line 733 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = MEDN; }
+#line 2596 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 92:
+#line 735 "conffile.y" /* yacc.c:1661  */
     {
 				    if ((*(int*)(&yyvsp[0])) < 1 || (*(int*)(&yyvsp[0])) > 99) {
 						router_yyerror(&yylloc, yyscanner, rtr, ralloc, palloc,
@@ -2580,35 +2606,35 @@ yyreduce:
 				   	(*(struct _agcomp*)(&yyval)).ctype = PCTL;
 					(*(struct _agcomp*)(&yyval)).pctl = (unsigned char)(*(int*)(&yyvsp[0]));
 				   }
-#line 2584 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 92:
-#line 740 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = VAR; }
-#line 2590 "conffile.tab.c" /* yacc.c:1646  */
+#line 2610 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 93:
-#line 741 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _agcomp*)(&yyval)).ctype = SDEV; }
-#line 2596 "conffile.tab.c" /* yacc.c:1646  */
+#line 744 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = VAR; }
+#line 2616 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 94:
-#line 744 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = NULL; }
-#line 2602 "conffile.tab.c" /* yacc.c:1646  */
+#line 745 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _agcomp*)(&yyval)).ctype = SDEV; }
+#line 2622 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 95:
-#line 745 "conffile.y" /* yacc.c:1646  */
-    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
-#line 2608 "conffile.tab.c" /* yacc.c:1646  */
+#line 748 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = NULL; }
+#line 2628 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 96:
-#line 751 "conffile.y" /* yacc.c:1646  */
+#line 749 "conffile.y" /* yacc.c:1661  */
+    { (*(destinations **)(&yyval)) = (*(destinations **)(&yyvsp[0])); }
+#line 2634 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 97:
+#line 755 "conffile.y" /* yacc.c:1661  */
     {
 		char *err = router_set_statistics(rtr, (*(destinations **)(&yyvsp[-1])));
 		if (err != NULL) {
@@ -2619,11 +2645,11 @@ yyreduce:
 				"removed in a future version, use 'statistics send to ...' "
 				"instead\n");
 	}
-#line 2623 "conffile.tab.c" /* yacc.c:1646  */
+#line 2649 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 97:
-#line 771 "conffile.y" /* yacc.c:1646  */
+  case 98:
+#line 775 "conffile.y" /* yacc.c:1661  */
     {
 		  	char *err;
 		  	err = router_set_collectorvals(rtr, (*(int*)(&yyvsp[-4])), (*(char **)(&yyvsp[-2])), (*(col_mode*)(&yyvsp[-3])));
@@ -2641,17 +2667,17 @@ yyreduce:
 				}
 			}
 		  }
-#line 2645 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 98:
-#line 790 "conffile.y" /* yacc.c:1646  */
-    { (*(int*)(&yyval)) = -1; }
-#line 2651 "conffile.tab.c" /* yacc.c:1646  */
+#line 2671 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 99:
-#line 792 "conffile.y" /* yacc.c:1646  */
+#line 794 "conffile.y" /* yacc.c:1661  */
+    { (*(int*)(&yyval)) = -1; }
+#line 2677 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 100:
+#line 796 "conffile.y" /* yacc.c:1661  */
     {
 					   	if ((*(int*)(&yyvsp[-1])) <= 0) {
 							router_yyerror(&yylloc, yyscanner, rtr,
@@ -2660,35 +2686,35 @@ yyreduce:
 						}
 						(*(int*)(&yyval)) = (*(int*)(&yyvsp[-1]));
 					   }
-#line 2664 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 100:
-#line 802 "conffile.y" /* yacc.c:1646  */
-    { (*(col_mode*)(&yyval)) = CUM; }
-#line 2670 "conffile.tab.c" /* yacc.c:1646  */
+#line 2690 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 101:
-#line 803 "conffile.y" /* yacc.c:1646  */
-    { (*(col_mode*)(&yyval)) = SUB; }
-#line 2676 "conffile.tab.c" /* yacc.c:1646  */
+#line 806 "conffile.y" /* yacc.c:1661  */
+    { (*(col_mode*)(&yyval)) = CUM; }
+#line 2696 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 102:
-#line 806 "conffile.y" /* yacc.c:1646  */
-    { (*(char **)(&yyval)) = NULL; }
-#line 2682 "conffile.tab.c" /* yacc.c:1646  */
+#line 807 "conffile.y" /* yacc.c:1661  */
+    { (*(col_mode*)(&yyval)) = SUB; }
+#line 2702 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 103:
-#line 807 "conffile.y" /* yacc.c:1646  */
-    { (*(char **)(&yyval)) = (*(char **)(&yyvsp[0])); }
-#line 2688 "conffile.tab.c" /* yacc.c:1646  */
+#line 810 "conffile.y" /* yacc.c:1661  */
+    { (*(char **)(&yyval)) = NULL; }
+#line 2708 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 104:
-#line 813 "conffile.y" /* yacc.c:1646  */
+#line 811 "conffile.y" /* yacc.c:1661  */
+    { (*(char **)(&yyval)) = (*(char **)(&yyvsp[0])); }
+#line 2714 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 105:
+#line 817 "conffile.y" /* yacc.c:1661  */
     {
 	  	struct _rcptr *walk;
 		char *err;
@@ -2704,11 +2730,11 @@ yyreduce:
 			}
 		}
 	  }
-#line 2708 "conffile.tab.c" /* yacc.c:1646  */
+#line 2734 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 105:
-#line 831 "conffile.y" /* yacc.c:1646  */
+  case 106:
+#line 835 "conffile.y" /* yacc.c:1661  */
     {
 			if (((*(struct _lsnr **)(&yyval)) = ra_malloc(palloc, sizeof(struct _lsnr))) == NULL) {
 				logerr("malloc failed\n");
@@ -2730,11 +2756,11 @@ yyreduce:
 				}
 			}
 		}
-#line 2734 "conffile.tab.c" /* yacc.c:1646  */
+#line 2760 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 106:
-#line 854 "conffile.y" /* yacc.c:1646  */
+  case 107:
+#line 858 "conffile.y" /* yacc.c:1661  */
     {
 							if (((*(struct _rcptr_trsp **)(&yyval)) = ra_malloc(palloc,
 									sizeof(struct _rcptr_trsp))) == NULL)
@@ -2744,11 +2770,11 @@ yyreduce:
 							}
 							(*(struct _rcptr_trsp **)(&yyval))->mode = W_PLAIN;
 						}
-#line 2748 "conffile.tab.c" /* yacc.c:1646  */
+#line 2774 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 107:
-#line 863 "conffile.y" /* yacc.c:1646  */
+  case 108:
+#line 867 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_GZIP
 							if (((*(struct _rcptr_trsp **)(&yyval)) = ra_malloc(palloc,
@@ -2765,11 +2791,11 @@ yyreduce:
 							YYERROR;
 #endif
 						}
-#line 2769 "conffile.tab.c" /* yacc.c:1646  */
+#line 2795 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 108:
-#line 879 "conffile.y" /* yacc.c:1646  */
+  case 109:
+#line 883 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_LZ4
 							if (((*(struct _rcptr_trsp **)(&yyval)) = ra_malloc(palloc,
@@ -2786,11 +2812,11 @@ yyreduce:
 							YYERROR;
 #endif
 						}
-#line 2790 "conffile.tab.c" /* yacc.c:1646  */
+#line 2816 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 109:
-#line 895 "conffile.y" /* yacc.c:1646  */
+  case 110:
+#line 899 "conffile.y" /* yacc.c:1661  */
     {
 #ifdef HAVE_SSL
 							if (((*(struct _rcptr_trsp **)(&yyval)) = ra_malloc(palloc,
@@ -2808,29 +2834,29 @@ yyreduce:
 							YYERROR;
 #endif
 						}
-#line 2812 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 110:
-#line 914 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _rcptr **)(&yyvsp[-1]))->next = (*(struct _rcptr **)(&yyvsp[0])); (*(struct _rcptr **)(&yyval)) = (*(struct _rcptr **)(&yyvsp[-1])); }
-#line 2818 "conffile.tab.c" /* yacc.c:1646  */
+#line 2838 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 111:
-#line 917 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _rcptr **)(&yyval)) = NULL; }
-#line 2824 "conffile.tab.c" /* yacc.c:1646  */
+#line 918 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _rcptr **)(&yyvsp[-1]))->next = (*(struct _rcptr **)(&yyvsp[0])); (*(struct _rcptr **)(&yyval)) = (*(struct _rcptr **)(&yyvsp[-1])); }
+#line 2844 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 112:
-#line 918 "conffile.y" /* yacc.c:1646  */
-    { (*(struct _rcptr **)(&yyval)) = (*(struct _rcptr **)(&yyvsp[0]));   }
-#line 2830 "conffile.tab.c" /* yacc.c:1646  */
+#line 921 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _rcptr **)(&yyval)) = NULL; }
+#line 2850 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 113:
-#line 922 "conffile.y" /* yacc.c:1646  */
+#line 922 "conffile.y" /* yacc.c:1661  */
+    { (*(struct _rcptr **)(&yyval)) = (*(struct _rcptr **)(&yyvsp[0]));   }
+#line 2856 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 114:
+#line 926 "conffile.y" /* yacc.c:1661  */
     {
 			char *err;
 			void *hint = NULL;
@@ -2867,11 +2893,11 @@ yyreduce:
 			free(hint);
 			(*(struct _rcptr **)(&yyval))->next = NULL;
 		}
-#line 2871 "conffile.tab.c" /* yacc.c:1646  */
+#line 2897 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
-  case 114:
-#line 959 "conffile.y" /* yacc.c:1646  */
+  case 115:
+#line 963 "conffile.y" /* yacc.c:1661  */
     {
 			char *err;
 
@@ -2891,32 +2917,32 @@ yyreduce:
 			}
 			(*(struct _rcptr **)(&yyval))->next = NULL;
 		}
-#line 2895 "conffile.tab.c" /* yacc.c:1646  */
-    break;
-
-  case 115:
-#line 980 "conffile.y" /* yacc.c:1646  */
-    { (*(con_proto*)(&yyval)) = CON_TCP; }
-#line 2901 "conffile.tab.c" /* yacc.c:1646  */
+#line 2921 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 116:
-#line 981 "conffile.y" /* yacc.c:1646  */
-    { (*(con_proto*)(&yyval)) = CON_UDP; }
-#line 2907 "conffile.tab.c" /* yacc.c:1646  */
+#line 984 "conffile.y" /* yacc.c:1661  */
+    { (*(con_proto*)(&yyval)) = CON_TCP; }
+#line 2927 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
   case 117:
-#line 987 "conffile.y" /* yacc.c:1646  */
+#line 985 "conffile.y" /* yacc.c:1661  */
+    { (*(con_proto*)(&yyval)) = CON_UDP; }
+#line 2933 "conffile.tab.c" /* yacc.c:1661  */
+    break;
+
+  case 118:
+#line 991 "conffile.y" /* yacc.c:1661  */
     {
 	   	if (router_readconfig(rtr, (*(char **)(&yyvsp[0])), 0, 0, 0, 0, 0, 0, 0) == NULL)
 			YYERROR;
 	   }
-#line 2916 "conffile.tab.c" /* yacc.c:1646  */
+#line 2942 "conffile.tab.c" /* yacc.c:1661  */
     break;
 
 
-#line 2920 "conffile.tab.c" /* yacc.c:1646  */
+#line 2946 "conffile.tab.c" /* yacc.c:1661  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires

--- a/conffile.tab.h
+++ b/conffile.tab.h
@@ -48,7 +48,7 @@
 extern int router_yydebug;
 #endif
 /* "%code requires" blocks.  */
-#line 11 "conffile.y" /* yacc.c:1909  */
+#line 11 "conffile.y" /* yacc.c:1915  */
 
 struct _clust {
 	enum clusttype t;
@@ -59,6 +59,7 @@ struct _clhost {
 	int port;
 	char *inst;
 	int proto;
+	con_type type;
 	con_trnsp trnsp;
 	void *saddr;
 	void *hint;
@@ -92,7 +93,7 @@ struct _rcptr_trsp {
 	char *pemcert;
 };
 
-#line 96 "conffile.tab.h" /* yacc.c:1909  */
+#line 97 "conffile.tab.h" /* yacc.c:1915  */
 
 /* Token type.  */
 #ifndef ROUTER_YYTOKENTYPE
@@ -159,16 +160,17 @@ struct _rcptr_trsp {
     crLISTEN = 315,
     crTYPE = 316,
     crLINEMODE = 317,
-    crTRANSPORT = 318,
-    crGZIP = 319,
-    crLZ4 = 320,
-    crSSL = 321,
-    crUNIX = 322,
-    crINCLUDE = 323,
-    crCOMMENT = 324,
-    crSTRING = 325,
-    crUNEXPECTED = 326,
-    crINTVAL = 327
+    crSYSLOGMODE = 318,
+    crTRANSPORT = 319,
+    crGZIP = 320,
+    crLZ4 = 321,
+    crSSL = 322,
+    crUNIX = 323,
+    crINCLUDE = 324,
+    crCOMMENT = 325,
+    crSTRING = 326,
+    crUNEXPECTED = 327,
+    crINTVAL = 328
   };
 #endif
 
@@ -200,6 +202,8 @@ union ROUTER_YYSTYPE
   con_proto rcptr_proto;
   /* cluster_opt_transport  */
   con_trnsp cluster_opt_transport;
+  /* cluster_opt_type  */
+  con_type cluster_opt_type;
   /* match_opt_send_to  */
   destinations * match_opt_send_to;
   /* match_send_to  */
@@ -280,7 +284,7 @@ union ROUTER_YYSTYPE
   struct _rcptr * receptor;
   /* transport_mode  */
   struct _rcptr_trsp * transport_mode;
-#line 284 "conffile.tab.h" /* yacc.c:1909  */
+#line 288 "conffile.tab.h" /* yacc.c:1915  */
 };
 
 typedef union ROUTER_YYSTYPE ROUTER_YYSTYPE;

--- a/conffile.yy.c
+++ b/conffile.yy.c
@@ -1,6 +1,6 @@
-#line 1 "conffile.yy.c"
+#line 2 "conffile.yy.c"
 
-#line 3 "conffile.yy.c"
+#line 4 "conffile.yy.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -8,232 +8,10 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 4
+#define YY_FLEX_MINOR_VERSION 5
+#define YY_FLEX_SUBMINOR_VERSION 35
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
-#endif
-
-#ifdef yy_create_buffer
-#define router_yy_create_buffer_ALREADY_DEFINED
-#else
-#define yy_create_buffer router_yy_create_buffer
-#endif
-
-#ifdef yy_delete_buffer
-#define router_yy_delete_buffer_ALREADY_DEFINED
-#else
-#define yy_delete_buffer router_yy_delete_buffer
-#endif
-
-#ifdef yy_scan_buffer
-#define router_yy_scan_buffer_ALREADY_DEFINED
-#else
-#define yy_scan_buffer router_yy_scan_buffer
-#endif
-
-#ifdef yy_scan_string
-#define router_yy_scan_string_ALREADY_DEFINED
-#else
-#define yy_scan_string router_yy_scan_string
-#endif
-
-#ifdef yy_scan_bytes
-#define router_yy_scan_bytes_ALREADY_DEFINED
-#else
-#define yy_scan_bytes router_yy_scan_bytes
-#endif
-
-#ifdef yy_init_buffer
-#define router_yy_init_buffer_ALREADY_DEFINED
-#else
-#define yy_init_buffer router_yy_init_buffer
-#endif
-
-#ifdef yy_flush_buffer
-#define router_yy_flush_buffer_ALREADY_DEFINED
-#else
-#define yy_flush_buffer router_yy_flush_buffer
-#endif
-
-#ifdef yy_load_buffer_state
-#define router_yy_load_buffer_state_ALREADY_DEFINED
-#else
-#define yy_load_buffer_state router_yy_load_buffer_state
-#endif
-
-#ifdef yy_switch_to_buffer
-#define router_yy_switch_to_buffer_ALREADY_DEFINED
-#else
-#define yy_switch_to_buffer router_yy_switch_to_buffer
-#endif
-
-#ifdef yypush_buffer_state
-#define router_yypush_buffer_state_ALREADY_DEFINED
-#else
-#define yypush_buffer_state router_yypush_buffer_state
-#endif
-
-#ifdef yypop_buffer_state
-#define router_yypop_buffer_state_ALREADY_DEFINED
-#else
-#define yypop_buffer_state router_yypop_buffer_state
-#endif
-
-#ifdef yyensure_buffer_stack
-#define router_yyensure_buffer_stack_ALREADY_DEFINED
-#else
-#define yyensure_buffer_stack router_yyensure_buffer_stack
-#endif
-
-#ifdef yylex
-#define router_yylex_ALREADY_DEFINED
-#else
-#define yylex router_yylex
-#endif
-
-#ifdef yyrestart
-#define router_yyrestart_ALREADY_DEFINED
-#else
-#define yyrestart router_yyrestart
-#endif
-
-#ifdef yylex_init
-#define router_yylex_init_ALREADY_DEFINED
-#else
-#define yylex_init router_yylex_init
-#endif
-
-#ifdef yylex_init_extra
-#define router_yylex_init_extra_ALREADY_DEFINED
-#else
-#define yylex_init_extra router_yylex_init_extra
-#endif
-
-#ifdef yylex_destroy
-#define router_yylex_destroy_ALREADY_DEFINED
-#else
-#define yylex_destroy router_yylex_destroy
-#endif
-
-#ifdef yyget_debug
-#define router_yyget_debug_ALREADY_DEFINED
-#else
-#define yyget_debug router_yyget_debug
-#endif
-
-#ifdef yyset_debug
-#define router_yyset_debug_ALREADY_DEFINED
-#else
-#define yyset_debug router_yyset_debug
-#endif
-
-#ifdef yyget_extra
-#define router_yyget_extra_ALREADY_DEFINED
-#else
-#define yyget_extra router_yyget_extra
-#endif
-
-#ifdef yyset_extra
-#define router_yyset_extra_ALREADY_DEFINED
-#else
-#define yyset_extra router_yyset_extra
-#endif
-
-#ifdef yyget_in
-#define router_yyget_in_ALREADY_DEFINED
-#else
-#define yyget_in router_yyget_in
-#endif
-
-#ifdef yyset_in
-#define router_yyset_in_ALREADY_DEFINED
-#else
-#define yyset_in router_yyset_in
-#endif
-
-#ifdef yyget_out
-#define router_yyget_out_ALREADY_DEFINED
-#else
-#define yyget_out router_yyget_out
-#endif
-
-#ifdef yyset_out
-#define router_yyset_out_ALREADY_DEFINED
-#else
-#define yyset_out router_yyset_out
-#endif
-
-#ifdef yyget_leng
-#define router_yyget_leng_ALREADY_DEFINED
-#else
-#define yyget_leng router_yyget_leng
-#endif
-
-#ifdef yyget_text
-#define router_yyget_text_ALREADY_DEFINED
-#else
-#define yyget_text router_yyget_text
-#endif
-
-#ifdef yyget_lineno
-#define router_yyget_lineno_ALREADY_DEFINED
-#else
-#define yyget_lineno router_yyget_lineno
-#endif
-
-#ifdef yyset_lineno
-#define router_yyset_lineno_ALREADY_DEFINED
-#else
-#define yyset_lineno router_yyset_lineno
-#endif
-
-#ifdef yyget_column
-#define router_yyget_column_ALREADY_DEFINED
-#else
-#define yyget_column router_yyget_column
-#endif
-
-#ifdef yyset_column
-#define router_yyset_column_ALREADY_DEFINED
-#else
-#define yyset_column router_yyset_column
-#endif
-
-#ifdef yywrap
-#define router_yywrap_ALREADY_DEFINED
-#else
-#define yywrap router_yywrap
-#endif
-
-#ifdef yyget_lval
-#define router_yyget_lval_ALREADY_DEFINED
-#else
-#define yyget_lval router_yyget_lval
-#endif
-
-#ifdef yyset_lval
-#define router_yyset_lval_ALREADY_DEFINED
-#else
-#define yyset_lval router_yyset_lval
-#endif
-
-#ifdef yyalloc
-#define router_yyalloc_ALREADY_DEFINED
-#else
-#define yyalloc router_yyalloc
-#endif
-
-#ifdef yyrealloc
-#define router_yyrealloc_ALREADY_DEFINED
-#else
-#define yyrealloc router_yyrealloc
-#endif
-
-#ifdef yyfree
-#define router_yyfree_ALREADY_DEFINED
-#else
-#define yyfree router_yyfree
 #endif
 
 /* First, we deal with  platform-specific or compiler-specific issues. */
@@ -269,6 +47,7 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
+typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -276,6 +55,7 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
+#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -306,32 +86,38 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
-#ifndef SIZE_MAX
-#define SIZE_MAX               (~(size_t)0)
-#endif
-
-#endif /* ! C99 */
-
 #endif /* ! FLEXINT_H */
 
-/* begin standard C++ headers. */
+#ifdef __cplusplus
 
-/* TODO: this is always defined, so inline it */
+/* The "const" storage-class-modifier is valid. */
+#define YY_USE_CONST
+
+#else	/* ! __cplusplus */
+
+/* C99 requires __STDC__ to be defined as 1. */
+#if defined (__STDC__)
+
+#define YY_USE_CONST
+
+#endif	/* defined (__STDC__) */
+#endif	/* ! __cplusplus */
+
+#ifdef YY_USE_CONST
 #define yyconst const
-
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yynoreturn
+#define yyconst
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an
- *   integer in range [0..255] for use as an array index.
+/* Promotes a possibly negative, possibly signed char to an unsigned
+ * integer for use as an array index.  If the signed char is negative,
+ * we want to instead treat it as an 8-bit unsigned char, hence the
+ * double cast.
  */
-#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
+#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
 
 /* An opaque pointer. */
 #ifndef YY_TYPEDEF_YY_SCANNER_T
@@ -355,29 +141,25 @@ typedef void* yyscan_t;
  * definition of BEGIN.
  */
 #define BEGIN yyg->yy_start = 1 + 2 *
+
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START ((yyg->yy_start - 1) / 2)
 #define YYSTATE YY_START
+
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
+
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart( yyin , yyscanner )
+#define YY_NEW_FILE router_yyrestart(yyin ,yyscanner )
+
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
-#ifdef __ia64__
-/* On IA-64, the buffer size is 16k, not 8k.
- * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
- * Ditto for the __ia64__ case accordingly.
- */
-#define YY_BUF_SIZE 32768
-#else
 #define YY_BUF_SIZE 16384
-#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -397,26 +179,19 @@ typedef size_t yy_size_t;
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-    
+
     /* Note: We specifically omit the test for yy_rule_can_match_eol because it requires
      *       access to the local variable yy_act. Since yyless() is a macro, it would break
-     *       existing scanners that call yyless() from OUTSIDE yylex.
+     *       existing scanners that call yyless() from OUTSIDE router_yylex. 
      *       One obvious solution it to make yy_act a global. I tried that, and saw
      *       a 5% performance hit in a non-yylineno scanner, because yy_act is
      *       normally declared as a register variable-- so it is not worth it.
      */
     #define  YY_LESS_LINENO(n) \
             do { \
-                int yyl;\
+                yy_size_t yyl;\
                 for ( yyl = n; yyl < yyleng; ++yyl )\
                     if ( yytext[yyl] == '\n' )\
-                        --yylineno;\
-            }while(0)
-    #define YY_LINENO_REWIND_TO(dst) \
-            do {\
-                const char *p;\
-                for ( p = yy_cp-1; p >= (dst); --p)\
-                    if ( *p == '\n' )\
                         --yylineno;\
             }while(0)
     
@@ -433,6 +208,7 @@ typedef size_t yy_size_t;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
+
 #define unput(c) yyunput( c, yyg->yytext_ptr , yyscanner )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -447,12 +223,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	int yy_buf_size;
+	yy_size_t yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -475,7 +251,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-
+    
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -492,7 +268,7 @@ struct yy_buffer_state
 	 * possible backing-up.
 	 *
 	 * When we actually see the EOF, we change the status to "new"
-	 * (via yyrestart()), so that the user can continue scanning by
+	 * (via router_yyrestart()), so that the user can continue scanning by
 	 * just pointing yyin at a new input file.
 	 */
 #define YY_BUFFER_EOF_PENDING 2
@@ -509,79 +285,86 @@ struct yy_buffer_state
 #define YY_CURRENT_BUFFER ( yyg->yy_buffer_stack \
                           ? yyg->yy_buffer_stack[yyg->yy_buffer_stack_top] \
                           : NULL)
+
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
 #define YY_CURRENT_BUFFER_LVALUE yyg->yy_buffer_stack[yyg->yy_buffer_stack_top]
 
-void yyrestart ( FILE *input_file , yyscan_t yyscanner );
-void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size , yyscan_t yyscanner );
-void yy_delete_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
-void yy_flush_buffer ( YY_BUFFER_STATE b , yyscan_t yyscanner );
-void yypush_buffer_state ( YY_BUFFER_STATE new_buffer , yyscan_t yyscanner );
-void yypop_buffer_state ( yyscan_t yyscanner );
+void router_yyrestart (FILE *input_file ,yyscan_t yyscanner );
+void router_yy_switch_to_buffer (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
+YY_BUFFER_STATE router_yy_create_buffer (FILE *file,int size ,yyscan_t yyscanner );
+void router_yy_delete_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
+void router_yy_flush_buffer (YY_BUFFER_STATE b ,yyscan_t yyscanner );
+void router_yypush_buffer_state (YY_BUFFER_STATE new_buffer ,yyscan_t yyscanner );
+void router_yypop_buffer_state (yyscan_t yyscanner );
 
-static void yyensure_buffer_stack ( yyscan_t yyscanner );
-static void yy_load_buffer_state ( yyscan_t yyscanner );
-static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file , yyscan_t yyscanner );
-#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER , yyscanner)
+static void router_yyensure_buffer_stack (yyscan_t yyscanner );
+static void router_yy_load_buffer_state (yyscan_t yyscanner );
+static void router_yy_init_buffer (YY_BUFFER_STATE b,FILE *file ,yyscan_t yyscanner );
 
-YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_string ( const char *yy_str , yyscan_t yyscanner );
-YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len , yyscan_t yyscanner );
+#define YY_FLUSH_BUFFER router_yy_flush_buffer(YY_CURRENT_BUFFER ,yyscanner)
 
-void *yyalloc ( yy_size_t , yyscan_t yyscanner );
-void *yyrealloc ( void *, yy_size_t , yyscan_t yyscanner );
-void yyfree ( void * , yyscan_t yyscanner );
+YY_BUFFER_STATE router_yy_scan_buffer (char *base,yy_size_t size ,yyscan_t yyscanner );
+YY_BUFFER_STATE router_yy_scan_string (yyconst char *yy_str ,yyscan_t yyscanner );
+YY_BUFFER_STATE router_yy_scan_bytes (yyconst char *bytes,yy_size_t len ,yyscan_t yyscanner );
 
-#define yy_new_buffer yy_create_buffer
+void *router_yyalloc (yy_size_t ,yyscan_t yyscanner );
+void *router_yyrealloc (void *,yy_size_t ,yyscan_t yyscanner );
+void router_yyfree (void * ,yyscan_t yyscanner );
+
+#define yy_new_buffer router_yy_create_buffer
+
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
-        yyensure_buffer_stack (yyscanner); \
+        router_yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
+            router_yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
+
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
-        yyensure_buffer_stack (yyscanner); \
+        router_yyensure_buffer_stack (yyscanner); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner); \
+            router_yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
+
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
 
-#define router_yywrap(yyscanner) (/*CONSTCOND*/1)
+#define router_yywrap(n) 1
 #define YY_SKIP_YYWRAP
-typedef flex_uint8_t YY_CHAR;
+
+typedef unsigned char YY_CHAR;
 
 typedef int yy_state_type;
 
 #define yytext_ptr yytext_r
 
-static yy_state_type yy_get_previous_state ( yyscan_t yyscanner );
-static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  , yyscan_t yyscanner);
-static int yy_get_next_buffer ( yyscan_t yyscanner );
-static void yynoreturn yy_fatal_error ( const char* msg , yyscan_t yyscanner );
+static yy_state_type yy_get_previous_state (yyscan_t yyscanner );
+static yy_state_type yy_try_NUL_trans (yy_state_type current_state  ,yyscan_t yyscanner);
+static int yy_get_next_buffer (yyscan_t yyscanner );
+static void yy_fatal_error (yyconst char msg[] ,yyscan_t yyscanner );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	yyg->yytext_ptr = yy_bp; \
-	yyleng = (int) (yy_cp - yy_bp); \
+	yyleng = (yy_size_t) (yy_cp - yy_bp); \
 	yyg->yy_hold_char = *yy_cp; \
 	*yy_cp = '\0'; \
 	yyg->yy_c_buf_p = yy_cp;
-#define YY_NUM_RULES 103
-#define YY_END_OF_BUFFER 104
+
+#define YY_NUM_RULES 104
+#define YY_END_OF_BUFFER 105
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -589,69 +372,70 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static const flex_int16_t yy_accept[529] =
+static yyconst flex_int16_t yy_accept[534] =
     {   0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,  104,  102,
-       97,   98,  102,  101,  102,  102,  102,  102,  102,  102,
-      102,  102,  102,  102,  102,  102,  102,  102,  102,  102,
-      102,  102,  102,   99,  102,  102,  102,  102,  102,  102,
-      102,  102,  102,  102,  102,  102,  102,  102,  102,  102,
-      102,  102,  102,  102,  102,  102,  102,  102,   95,   95,
-       93,   92,   95,   95,  102,   91,  100,   99,   21,  100,
-      100,  100,  100,  100,  100,  100,  100,  100,   23,  100,
+        0,    0,    0,    0,    0,    0,    0,    0,  105,  103,
+       98,   99,  103,  102,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  100,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,  103,  103,
+      103,  103,  103,  103,  103,  103,  103,  103,   96,   96,
+       94,   93,   96,   96,  103,   92,  101,  100,   22,  101,
+      101,  101,  101,  101,  101,  101,  101,  101,   24,  101,
 
-      100,  100,  100,  100,  100,  100,  100,  100,   97,   98,
-        0,   96,    0,    0,    0,    0,    0,    0,    0,    0,
+      101,  101,  101,  101,  101,  101,  101,  101,   98,   99,
+        0,   97,    0,    0,    0,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,   31,    0,    0,   99,    0,   42,    0,
-        0,    0,    0,    0,    0,    0,    0,    0,   46,    0,
-        0,    0,    0,    0,   64,    0,    0,    0,    0,    0,
+        0,    0,    0,   32,    0,    0,  100,    0,   43,    0,
+        0,    0,    0,    0,    0,    0,    0,    0,   47,    0,
+        0,    0,    0,    0,   65,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,   95,   95,   95,   94,  100,  100,   99,
-      100,  100,   11,  100,  100,  100,  100,  100,  100,  100,
-      100,  100,  100,  100,  100,  100,  100,  100,  100,  100,
+        0,    0,    0,   96,   96,   96,   95,  101,  101,  100,
+      101,  101,   11,  101,  101,  101,  101,  101,  101,  101,
+      101,  101,  101,  101,  101,  101,  101,  101,  101,  101,
 
-      100,  100,  100,    0,    0,    0,    0,    0,    0,    0,
+      101,  101,  101,  101,    0,    0,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-       26,    0,    0,    0,    0,    0,    0,    0,   58,    0,
-       52,    0,    0,   45,    0,   54,    0,    0,   56,    0,
-        0,    0,    0,    0,   50,    0,    0,    0,    0,    0,
+        0,   27,    0,    0,    0,    0,    0,    0,    0,   59,
+        0,   53,    0,    0,   46,    0,   55,    0,    0,   57,
+        0,    0,    0,    0,    0,   51,    0,    0,    0,    0,
         0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,   88,    0,   87,    0,    0,  100,  100,  100,   19,
-      100,  100,   20,  100,   14,  100,  100,   13,  100,  100,
-      100,  100,  100,  100,   84,  100,   85,  100,    0,    0,
-        0,    0,    0,    0,   66,    0,    0,    0,    0,   10,
+        0,    0,   89,    0,   88,    0,    0,  101,  101,  101,
+       20,  101,  101,   21,  101,  101,   14,  101,  101,   13,
+      101,  101,  101,  101,  101,  101,   85,  101,   86,  101,
+        0,    0,    0,    0,    0,    0,   67,    0,    0,    0,
 
-        0,    0,    0,   27,   25,    0,   30,   33,    0,   35,
-        0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,   65,    0,    0,    0,    0,    0,    0,    0,
-        0,    0,    0,    0,    0,    0,    0,   78,    0,   77,
-        0,    0,   80,   89,  100,  100,   18,  100,  100,  100,
-       33,  100,   15,  100,  100,   30,  100,  100,   83,  100,
-      100,    0,    0,    0,    0,   22,    0,    0,    0,    0,
-        0,    0,    0,    0,   28,   29,   40,    0,    0,    0,
-       51,    0,    0,    0,    0,    0,    0,    0,   43,    0,
-        0,    0,    0,   63,    0,   74,    0,   70,    0,    0,
+        0,   10,    0,    0,    0,   28,   26,    0,   31,   34,
+        0,   36,    0,    0,    0,    0,    0,    0,    0,    0,
+        0,    0,    0,    0,   66,    0,    0,    0,    0,    0,
+        0,    0,    0,    0,    0,    0,    0,    0,    0,   79,
+        0,   78,    0,    0,   81,   90,  101,  101,   19,  101,
+      101,  101,   34,  101,  101,   15,  101,  101,   31,  101,
+      101,   84,  101,  101,    0,    0,    0,    0,   23,    0,
+        0,    0,    0,    0,    0,    0,    0,   29,   30,   41,
+        0,    0,    0,   52,    0,    0,    0,    0,    0,    0,
+        0,   44,    0,    0,    0,    0,   64,    0,   75,    0,
 
-       72,    0,    0,    0,   86,  100,  100,  100,   12,  100,
-      100,  100,   28,  100,   37,   86,  100,    0,    0,    0,
-       79,    0,    0,    3,    0,    0,    0,    0,    0,    0,
-       47,    0,   39,    0,   59,   44,    0,    0,    0,   62,
-        0,    0,    0,    0,    0,    0,   76,    0,   69,    0,
-      100,  100,  100,  100,    5,  100,  100,    0,    1,   90,
-       34,    0,    0,    0,    0,    2,    0,   57,   48,   53,
-       55,    0,   38,   49,    0,    0,    0,    0,    0,   71,
-        0,  100,  100,  100,  100,  100,  100,    0,    0,    0,
-        4,    7,    0,    0,    0,   61,    0,   73,   75,   81,
+       71,    0,    0,   73,    0,    0,    0,   87,  101,  101,
+      101,   12,  101,  101,  101,  101,   29,  101,   38,   87,
+      101,    0,    0,    0,   80,    0,    0,    3,    0,    0,
+        0,    0,    0,    0,   48,    0,   40,    0,   60,   45,
+        0,    0,    0,   63,    0,    0,    0,    0,    0,    0,
+       77,    0,   70,    0,  101,  101,  101,   17,  101,    5,
+      101,  101,    0,    1,   91,   35,    0,    0,    0,    0,
+        2,    0,   58,   49,   54,   56,    0,   39,   50,    0,
+        0,    0,    0,    0,   72,    0,  101,  101,  101,  101,
+      101,  101,    0,    0,    0,    4,    7,    0,    0,    0,
 
-      100,   16,  100,  100,   24,  100,   36,    0,    6,    0,
-        0,   41,    0,   32,  100,   17,   82,   68,    0,   60,
-       67,  100,    0,   60,    9,    0,    8,    0
+       62,    0,   74,   76,   82,  101,   16,  101,  101,   25,
+      101,   37,    0,    6,    0,    0,   42,    0,   33,  101,
+       18,   83,   69,    0,   61,   68,  101,    0,   61,    9,
+        0,    8,    0
     } ;
 
-static const YY_CHAR yy_ec[256] =
+static yyconst flex_int32_t yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
@@ -683,7 +467,7 @@ static const YY_CHAR yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static const YY_CHAR yy_meta[41] =
+static yyconst flex_int32_t yy_meta[41] =
     {   0,
         1,    1,    2,    1,    3,    1,    4,    4,    4,    4,
         4,    1,    1,    5,    4,    4,    4,    4,    4,    4,
@@ -691,229 +475,232 @@ static const YY_CHAR yy_meta[41] =
         4,    4,    4,    4,    4,    4,    4,    4,    4,    4
     } ;
 
-static const flex_int16_t yy_base[537] =
+static yyconst flex_int16_t yy_base[542] =
     {   0,
         0,   32,   64,    0,   74,    0,    1,   21,  101,    0,
        36,   63,  130,    0,  152,    0,  186,  199,  213,    0,
-      246,    0,  139,  149,   39,   41,  275,    0,  795,  796,
-        3,  791,  790,  796,  770,  764,  761,  765,  772,  767,
-        9,  757,  769,  136,  749,  751,  755,  751,  750,   21,
-      749,  745,  748,    0,   66,  741,    1,   24,  100,  754,
-      754,   63,  103,  757,  740,  737,  749,  739,  732,  738,
-      734,  745,   43,  740,  739,  730,   86,   84,    0,   11,
-      758,  796,  139,    0,    0,  796,  746,  185,  796,  101,
-        0,  162,  247,   91,  116,  251,  278,  253,  745,  144,
+      246,    0,  139,  149,   39,   41,  275,    0,  805,  806,
+        3,  801,  800,  806,  780,  774,  771,  775,  782,  777,
+        9,  767,  779,  136,  759,  761,  765,  761,  760,   21,
+      759,  755,  758,    0,   66,  751,    1,   24,  100,  764,
+      764,   63,  103,  767,  750,  747,  759,  749,  742,  748,
+      744,  755,   43,  750,  749,  740,   86,   84,    0,   11,
+      768,  806,  139,    0,    0,  806,  756,  185,  806,  101,
+        0,  162,  247,   91,  116,  251,  278,  253,  755,  144,
 
-      129,    7,  142,  166,  170,  244,  131,  261,  205,  755,
-      754,  796,  734,  720,  736,  720,  718,  714,  721,  733,
-      709,  715,  722,  718,  708,  711,  714,  711,  707,  717,
-      703,  708,  706,  796,  711,  700,  279,  699,  796,  240,
-      714,  697,   23,  711,  698,  690,  708,  245,  796,  694,
-      179,  250,  697,  696,  796,  691,  698,  705,  686,  684,
-      698,  683,  696,  682,  276,  697,  679,  683,  681,  679,
-      678,  677,  683,    0,  296,  298,  796,  692,  300,  309,
-      299,  302,  691,  307,  311,  310,  313,  314,  315,  316,
-      317,  318,  320,  323,  321,  324,  325,  328,  336,  343,
+      129,    7,  142,  166,  170,  244,  131,  261,  205,  765,
+      764,  806,  744,  730,  746,  730,  728,  724,  731,  743,
+      719,  725,  732,  728,  718,  721,  724,  721,  717,  727,
+      713,  718,  716,  806,  721,  710,  289,  709,  806,  240,
+      724,  707,   23,  721,  708,  700,  718,  245,  806,  704,
+      179,  250,  707,  706,  806,  701,  708,  715,  696,  694,
+      708,  693,  706,  692,  276,  707,  689,  693,  691,  689,
+      688,  687,  693,    0,  287,  298,  806,  702,  300,  309,
+      299,  302,  701,  307,  311,  310,  313,  314,  315,  316,
+      317,  318,  319,  321,  323,  324,  325,  328,  333,  332,
 
-      332,  341,  345,  672,  670,  675,  667,  682,  667,  679,
-      663,  681,  678,  667,  673,  682,  654,  659,  658,  668,
-      796,  653,  667,  654,  655,  653,  662,  649,  796,  654,
-      796,  648,  649,  796,  653,  652,  651,  655,  649,  654,
-      641,  651,  637,  649,  639,  646,  641,  630,  629,  642,
-      632,  628,  639,  637,  637,  626,  636,  626,  630,  632,
-      617,  796,  630,  796,  611,    0,  277,  344,  349,  634,
-      350,  351,  633,  352,  632,  353,  356,  631,  357,  358,
-       72,  363,  365,  360,  630,  366,  629,  367,  622,  607,
-      605,  619,  615,  613,  796,  612,  605,  604,  603,  796,
+      346,  337,  344,  347,  682,  680,  685,  677,  692,  677,
+      689,  673,  691,  688,  677,  683,  692,  664,  669,  668,
+      678,  806,  663,  677,  664,  665,  663,  672,  659,  806,
+      664,  806,  658,  659,  806,  663,  662,  661,  665,  659,
+      664,  651,  661,  647,  659,  649,  656,  651,  640,  639,
+      652,  642,  638,  649,  647,  647,  636,  646,  636,  640,
+      642,  627,  806,  640,  806,  621,    0,  348,  350,  354,
+      644,  351,  355,  643,  356,  359,  642,  361,  358,  641,
+      363,  362,   72,  369,  366,  370,  640,  374,  639,  375,
+      632,  617,  615,  629,  625,  623,  806,  622,  615,  614,
 
-      616,  615,  615,  796,  796,  609,  796,  796,  606,  796,
-      595,  610,  605,  589,  589,  590,  593,  604,  592,  590,
-      597,  587,  796,  581,  594,  597,  579,  595,  590,  585,
-      576,  573,  567,  573,  580,  569,  573,  796,  577,  796,
-      572,  569,  796,  796,  584,  372,  583,  371,  374,  379,
-      582,  375,  581,  380,  381,  580,  391,  376,  579,  388,
-      392,  570,  571,  571,  560,  796,  554,  554,  565,  556,
-      548,  568,  550,  560,  796,  796,  796,  558,  545,  544,
-      796,  557,  541,  546,  554,  538,  543,  552,  796,  534,
-      537,  534,  538,  796,  533,  796,  545,  796,  528,  525,
+      613,  806,  626,  625,  625,  806,  806,  619,  806,  806,
+      616,  806,  605,  620,  615,  599,  599,  600,  603,  614,
+      602,  600,  607,  597,  806,  591,  604,  607,  589,  605,
+      600,  595,  586,  583,  577,  583,  590,  579,  583,  806,
+      587,  806,  582,  579,  806,  806,  594,  377,  593,  378,
+      380,  381,  592,  383,  385,  591,  388,  397,  590,  393,
+      386,  589,  400,  395,  580,  581,  581,  570,  806,  564,
+      564,  575,  566,  558,  578,  560,  570,  806,  806,  806,
+      568,  555,  554,  806,  567,  551,  556,  564,  548,  553,
+      562,  806,  544,  547,  544,  548,  806,  543,  806,  555,
 
-      796,  543,  527,  530,  796,  405,  397,  398,  545,  399,
-      400,  402,  544,  407,  543,  542,  408,  539,  522,  533,
-      796,  532,  517,  796,  535,  529,  530,  528,  517,  525,
-      796,  524,  796,  515,  796,  796,  514,  507,  507,  796,
-      500,  522,  519,  502,  503,  518,  796,  500,  796,  513,
-      410,  413,  419,  412,  517,  416,  422,  496,  796,  796,
-      796,  505,  510,  495,  503,  796,  489,  796,  796,  796,
-      796,  500,  796,  796,  495,  502,  497,  487,  492,  796,
-      498,  420,  423,  424,  427,  431,  430,  497,  498,  492,
-      796,  796,  504,  486,  481,  796,  493,  796,  796,  796,
+      806,  538,  535,  806,  553,  537,  540,  806,  412,  406,
+      405,  555,  409,  410,  407,  417,  554,  420,  553,  552,
+      408,  549,  532,  543,  806,  542,  527,  806,  545,  539,
+      540,  538,  527,  535,  806,  534,  806,  525,  806,  806,
+      524,  517,  517,  806,  510,  532,  529,  512,  513,  528,
+      806,  510,  806,  523,  419,  423,  427,  527,  426,  526,
+      431,  432,  505,  806,  806,  806,  514,  519,  504,  512,
+      806,  498,  806,  806,  806,  806,  509,  806,  806,  504,
+      511,  506,  496,  501,  806,  507,  433,  434,  436,  437,
+      438,  439,  506,  507,  501,  806,  806,  513,  495,  490,
 
-      434,  496,  432,  435,  495,  439,  796,  475,  796,  491,
-      479,  796,  458,  476,  441,  456,  447,  796,  445,  454,
-      796,  443,  281,  457,  198,   91,  796,  796,  473,  478,
-      483,  488,  492,  497,  499,  501
+      806,  502,  806,  806,  806,  441,  505,  443,  445,  504,
+      449,  806,  484,  806,  493,  481,  806,  467,  468,  450,
+      464,  454,  806,  280,  463,  806,  452,  270,  466,  198,
+       91,  806,  806,  483,  488,  493,  498,  502,  507,  509,
+      511
     } ;
 
-static const flex_int16_t yy_def[537] =
+static yyconst flex_int16_t yy_def[542] =
     {   0,
-      529,  529,  529,    3,    3,    5,    3,    3,    3,    9,
-        3,    3,    3,   13,    3,   15,  530,  530,  528,   19,
-       19,   21,   21,   21,   21,   21,   21,   27,  528,  528,
-      528,  528,  531,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  532,  532,
-      528,  528,  533,  532,  534,  528,  535,  535,  528,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  535,  535,
+      534,  534,  534,    3,    3,    5,    3,    3,    3,    9,
+        3,    3,    3,   13,    3,   15,  535,  535,  533,   19,
+       19,   21,   21,   21,   21,   21,   21,   27,  533,  533,
+      533,  533,  536,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  537,  537,
+      533,  533,  538,  537,  539,  533,  540,  540,  533,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
 
-      535,  535,  535,  535,  535,  535,  535,  535,  528,  528,
-      531,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  532,  532,  533,  528,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  535,  535,
+      540,  540,  540,  540,  540,  540,  540,  540,  533,  533,
+      536,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  537,  537,  538,  533,  540,  540,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
 
-      535,  535,  535,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  536,  535,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
+      540,  540,  540,  540,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  541,  540,  540,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
 
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  536,  535,  535,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  535,  535,  535,
-      535,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  541,  540,  540,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
+      540,  540,  540,  540,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
 
-      528,  528,  528,  528,  528,  536,  535,  535,  535,  535,
-      535,  535,  535,  535,  535,  535,  535,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      535,  535,  535,  535,  535,  535,  535,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  535,  535,  535,  535,  535,  535,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
+      533,  533,  533,  533,  533,  533,  533,  533,  541,  540,
+      540,  540,  540,  540,  540,  540,  540,  540,  540,  540,
+      540,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  540,  540,  540,  540,  540,  540,
+      540,  540,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  540,  540,  540,  540,
+      540,  540,  533,  533,  533,  533,  533,  533,  533,  533,
 
-      535,  535,  535,  535,  535,  535,  528,  528,  528,  528,
-      528,  528,  528,  535,  535,  535,  535,  528,  528,  528,
-      528,  535,  528,  528,  535,  528,  528,    0,  528,  528,
-      528,  528,  528,  528,  528,  528
+      533,  533,  533,  533,  533,  540,  540,  540,  540,  540,
+      540,  533,  533,  533,  533,  533,  533,  533,  540,  540,
+      540,  540,  533,  533,  533,  533,  540,  533,  533,  540,
+      533,  533,    0,  533,  533,  533,  533,  533,  533,  533,
+      533
     } ;
 
-static const flex_int16_t yy_nxt[837] =
+static yyconst flex_int16_t yy_nxt[847] =
     {   0,
-      528,   31,   32,   31,  109,   33,  109,  528,  137,  137,
-      137,   34,  175,  179,  175,   35,   30,   36,   30,  528,
-      179,   30,  197,   37,   53,   30,   38,   39,  119,  142,
+      533,   31,   32,   31,  109,   33,  109,  533,  137,  137,
+      137,   34,  175,  179,  175,   35,   30,   36,   30,  533,
+      179,   30,  198,   37,   53,   30,   38,   39,  119,  142,
       143,   40,   41,   31,   32,   31,   30,   33,   30,  182,
       132,   30,  120,   34,   53,   30,   87,   35,   87,   36,
-      232,   30,  144,   30,  133,   37,   30,  233,   38,   39,
+      233,   30,  144,   30,  133,   37,   30,  234,   38,   39,
        30,  145,  165,   40,   41,   31,   32,   31,   66,   33,
        87,   87,   87,   87,   87,   34,   87,  166,   30,   42,
        30,   43,  151,   30,   44,  179,  138,   30,   45,   30,
-      356,   30,   46,   47,   30,   66,  152,  153,   30,  139,
+      359,   30,   46,   47,   30,   66,  152,  153,   30,  139,
 
        48,  140,  172,  170,  179,   49,   50,   51,   52,   54,
-       54,   54,  173,  527,  179,  146,   55,   56,   57,  147,
+       54,   54,  173,  532,  179,  146,   55,   56,   57,  147,
        58,   30,  186,  148,  171,   30,  154,  181,   59,  179,
        60,   61,  155,   62,   63,  187,   64,   65,   54,   54,
-       54,  112,  179,  111,  179,   67,   87,   68,  196,   69,
+       54,  112,  179,  111,  179,   67,   87,   68,  197,   69,
        30,  123,  111,   70,   30,  179,   87,  179,  103,  124,
-       71,   72,   73,  202,  125,  126,   74,   30,  103,   30,
-       87,   87,   30,  195,   87,  179,   30,  198,   75,  179,
+       71,   72,   73,  203,  125,  126,   74,   30,  103,   30,
+       87,   87,   30,  196,   87,  179,   30,  199,   75,  179,
        87,   87,   76,  179,   87,   77,   78,   80,   81,   80,
-       82,   83,  183,  180,  180,  180,  241,   84,  179,   85,
+       82,   83,  183,  180,  180,  180,  242,   84,  179,   85,
 
-       80,   81,   80,   82,   83,  199,  109,  242,  109,  200,
+       80,   81,   80,   82,   83,  200,  109,  243,  109,  201,
        84,  179,   85,   30,   31,   32,   31,   86,   33,   87,
        87,   88,   88,   88,   34,   89,   87,   87,   87,   90,
        87,   87,   87,   87,   91,   87,   92,   87,   87,   93,
        87,   87,   87,   94,   95,   96,   97,   98,   87,   87,
-       87,   87,   87,   99,   87,   87,   87,  179,   30,  228,
-      179,  229,   87,  238,  179,  243,  179,   87,  244,   87,
-      184,  193,   87,  239,  179,  201,   87,  100,  101,   87,
-       87,  102,   87,  188,  189,  194,  185,  137,  137,  137,
-      179,  179,  203,  256,  346,  190,  104,  175,  526,  175,
+       87,   87,   87,   99,   87,   87,   87,  179,   30,  229,
+      179,  230,   87,  239,  179,  244,  179,   87,  245,   87,
+      184,  194,   87,  240,  179,  202,   87,  100,  101,   87,
+       87,  102,   87,  188,  189,  195,  185,  531,  175,  190,
+      175,  179,  204,  257,  528,  191,  104,  137,  137,  137,
 
-      112,  105,  111,  266,  257,  106,   87,  107,  108,  191,
-       87,  111,  179,  179,  267,  179,  192,  180,  180,  180,
-      179,  270,  179,  179,  179,  268,  179,  179,  179,  179,
-      179,  179,  276,  179,  179,  269,  179,  179,  179,  271,
-      273,  179,  279,  272,  274,  179,  275,  283,  277,  179,
-      278,  282,  281,  285,  179,  280,  179,  179,  179,  284,
-      288,  286,  179,  179,  179,  179,  179,  287,  348,  179,
-      179,  179,  354,  179,  347,  353,  179,  350,  179,  179,
-      179,  352,  351,  349,  179,  179,  357,  179,  179,  179,
-      359,  355,  179,  179,  179,  361,  358,  407,  408,  360,
+      112,  105,  111,  267,  258,  106,   87,  107,  108,  192,
+       87,  111,  179,  179,  268,  179,  193,  180,  180,  180,
+      179,  271,  179,  179,  179,  269,  179,  179,  179,  179,
+      179,  179,  179,  278,  179,  270,  179,  179,  179,  272,
+      274,  179,  281,  273,  275,  179,  179,  277,  276,  279,
+      179,  280,  285,  283,  284,  286,  287,  179,  282,  179,
+      179,  179,  290,  179,  179,  348,  288,  179,  179,  179,
+      289,  179,  179,  350,  179,  179,  179,  356,  357,  179,
+      349,  352,  179,  179,  351,  354,  353,  179,  179,  355,
+      179,  179,  360,  179,  179,  358,  179,  361,  179,  179,
 
-      413,  179,  410,  409,  179,  179,  412,  411,  266,  414,
-      179,  179,  179,  179,  415,  179,  453,  416,  406,  451,
-      179,  179,  456,  179,  417,  179,  179,  452,  455,  179,
-      454,  483,  179,  179,  484,  179,  179,  179,  457,  482,
-      179,  485,  502,  179,  179,  179,  501,  179,  179,  486,
-      505,  487,  179,  514,  179,  515,  179,  503,  504,  523,
-      179,  506,  524,  524,  524,  524,  524,  524,  516,  179,
-      522,  525,  517,   30,   30,   30,   30,   30,   79,   79,
-       79,   79,   79,  111,  111,  111,  111,  111,  174,  179,
-      521,  174,  176,  176,  176,  176,  176,  177,  520,  177,
+      362,  179,  410,  364,  413,  411,  179,  363,  179,  412,
+      179,  418,  414,  179,  416,  267,  417,  415,  179,  179,
+      179,  179,  179,  179,  419,  409,  457,  421,  455,  420,
+      179,  458,  179,  179,  456,  461,  179,  459,  462,  179,
+      179,  488,  489,  460,  179,  179,  179,  179,  487,  179,
+      179,  179,  179,  507,  179,  490,  179,  510,  179,  506,
+      519,  492,  179,  179,  491,  179,  520,  179,  509,  508,
+      511,  529,  529,  529,  529,  529,  529,  179,  521,  527,
+      530,  179,  522,   30,   30,   30,   30,   30,   79,   79,
+       79,   79,   79,  111,  111,  111,  111,  111,  174,  526,
 
-      177,  177,  178,  178,  345,  345,  519,  518,  179,  179,
-      513,  512,  511,  510,  509,  508,  507,  500,  499,  498,
-      497,  496,  495,  494,  493,  492,  491,  490,  489,  488,
-      179,  481,  480,  479,  478,  477,  476,  475,  474,  473,
-      472,  471,  470,  469,  468,  467,  466,  465,  464,  463,
-      462,  461,  460,  459,  458,  179,  179,  179,  179,  450,
-      449,  448,  447,  446,  445,  444,  443,  442,  441,  440,
-      439,  438,  437,  436,  435,  434,  433,  432,  431,  430,
-      429,  428,  427,  426,  425,  424,  423,  422,  421,  420,
-      419,  418,  179,  179,  179,  179,  179,  406,  405,  404,
+      525,  174,  176,  176,  176,  176,  176,  177,  524,  177,
+      177,  177,  178,  178,  347,  347,  523,  179,  179,  518,
+      517,  516,  515,  514,  513,  512,  505,  504,  503,  502,
+      501,  500,  499,  498,  497,  496,  495,  494,  493,  179,
+      179,  486,  485,  484,  483,  482,  481,  480,  479,  478,
+      477,  476,  475,  474,  473,  472,  471,  470,  469,  468,
+      467,  466,  465,  464,  463,  179,  179,  179,  179,  454,
+      453,  452,  451,  450,  449,  448,  447,  446,  445,  444,
+      443,  442,  441,  440,  439,  438,  437,  436,  435,  434,
+      433,  432,  431,  430,  429,  428,  427,  426,  425,  424,
 
-      403,  402,  401,  400,  399,  398,  397,  396,  395,  394,
-      393,  392,  391,  390,  389,  388,  387,  386,  385,  384,
-      383,  382,  381,  380,  379,  378,  377,  376,  375,  374,
-      373,  372,  371,  370,  369,  368,  367,  366,  365,  364,
-      363,  362,  179,  179,  179,  179,  179,  179,  344,  343,
-      342,  341,  340,  339,  338,  337,  336,  335,  334,  333,
-      332,  331,  330,  329,  328,  327,  326,  325,  324,  323,
-      322,  321,  320,  319,  318,  317,  316,  315,  314,  313,
-      312,  311,  310,  309,  308,  307,  306,  305,  304,  303,
-      302,  301,  300,  299,  298,  297,  296,  295,  294,  293,
+      423,  422,  179,  179,  179,  179,  179,  409,  408,  407,
+      406,  405,  404,  403,  402,  401,  400,  399,  398,  397,
+      396,  395,  394,  393,  392,  391,  390,  389,  388,  387,
+      386,  385,  384,  383,  382,  381,  380,  379,  378,  377,
+      376,  375,  374,  373,  372,  371,  370,  369,  368,  367,
+      366,  365,  179,  179,  179,  179,  179,  179,  346,  345,
+      344,  343,  342,  341,  340,  339,  338,  337,  336,  335,
+      334,  333,  332,  331,  330,  329,  328,  327,  326,  325,
+      324,  323,  322,  321,  320,  319,  318,  317,  316,  315,
+      314,  313,  312,  311,  310,  309,  308,  307,  306,  305,
 
-      292,  291,  290,  289,  179,  179,  265,  264,  263,  262,
-      261,  260,  259,  258,  255,  254,  253,  252,  251,  250,
-      249,  248,  247,  246,  245,  240,  237,  236,  235,  234,
-      231,  230,  227,  226,  225,  224,  223,  222,  221,  220,
-      219,  218,  217,  216,  215,  214,  213,  212,  211,  210,
-      209,  208,  207,  206,  205,  204,  112,  110,  179,  179,
+      304,  303,  302,  301,  300,  299,  298,  297,  296,  295,
+      294,  293,  292,  291,  179,  179,  266,  265,  264,  263,
+      262,  261,  260,  259,  256,  255,  254,  253,  252,  251,
+      250,  249,  248,  247,  246,  241,  238,  237,  236,  235,
+      232,  231,  228,  227,  226,  225,  224,  223,  222,  221,
+      220,  219,  218,  217,  216,  215,  214,  213,  212,  211,
+      210,  209,  208,  207,  206,  205,  112,  110,  179,  179,
       110,  169,  168,  167,  164,  163,  162,  161,  160,  159,
       158,  157,  156,  150,  149,  141,  136,  135,  134,  131,
       130,  129,  128,  127,  122,  121,  118,  117,  116,  115,
-      114,  113,  112,  110,  528,   29,  528,  528,  528,  528,
 
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528
+      114,  113,  112,  110,  533,   29,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533
     } ;
 
-static const flex_int16_t yy_chk[837] =
+static yyconst flex_int16_t yy_chk[847] =
     {   0,
         0,    1,    1,    1,   31,    1,   31,    0,   54,   54,
        54,    1,   80,   91,   80,    1,    7,    1,    7,    0,
@@ -923,11 +710,11 @@ static const flex_int16_t yy_chk[837] =
       143,   11,   58,   11,   50,    2,   11,  143,    2,    2,
        11,   58,   73,    2,    2,    3,    3,    3,   11,    3,
        25,   25,   26,   26,   25,    3,   26,   73,   12,    3,
-       12,    3,   62,   12,    3,  281,   55,   12,    3,    5,
-      281,    5,    5,    5,    5,   12,   62,   62,    5,   55,
+       12,    3,   62,   12,    3,  283,   55,   12,    3,    5,
+      283,    5,    5,    5,    5,   12,   62,   62,    5,   55,
 
         5,   55,   78,   77,   94,    5,    5,    5,    5,    9,
-        9,    9,   78,  526,   90,   59,    9,    9,    9,   59,
+        9,    9,   78,  531,   90,   59,    9,    9,    9,   59,
         9,    9,   94,   59,   77,    9,   63,   90,    9,   95,
         9,    9,   63,    9,    9,   95,    9,    9,   13,   13,
        13,   83,  101,   83,  107,   13,   23,   13,  101,   13,
@@ -938,61 +725,62 @@ static const flex_int16_t yy_chk[837] =
        17,   17,   92,   88,   88,   88,  151,   17,   88,   17,
 
        18,   18,   18,   18,   18,  104,  109,  151,  109,  105,
-       18,  525,   18,   19,   19,   19,   19,   19,   19,   19,
+       18,  530,   18,   19,   19,   19,   19,   19,   19,   19,
        19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
        19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
        19,   19,   19,   19,   19,   19,   19,   19,   19,   19,
        19,   19,   19,   21,   21,   21,   21,  106,   21,  140,
        93,  140,   21,  148,   96,  152,   98,   21,  152,   21,
        93,   98,   21,  148,  108,  106,   21,   21,   21,   21,
-       21,   21,   27,   96,   96,   98,   93,  137,  137,  137,
-      267,   97,  108,  165,  267,   97,   27,  175,  523,  175,
+       21,   21,   27,   96,   96,   98,   93,  528,  175,   96,
+      175,   97,  108,  165,  524,   97,   27,  137,  137,  137,
 
       176,   27,  176,  179,  165,   27,   27,   27,   27,   97,
        27,  176,  181,  179,  181,  182,   97,  180,  180,  180,
       184,  185,  180,  186,  185,  182,  187,  188,  189,  190,
-      191,  192,  191,  193,  195,  184,  194,  196,  197,  186,
-      188,  198,  194,  187,  189,  201,  190,  198,  192,  199,
-      193,  197,  196,  200,  202,  195,  200,  268,  203,  199,
-      203,  201,  269,  271,  272,  274,  276,  202,  269,  277,
-      279,  280,  279,  284,  268,  277,  282,  272,  283,  286,
-      288,  276,  274,  271,  348,  346,  282,  349,  352,  358,
-      284,  280,  350,  354,  355,  288,  283,  346,  348,  286,
+      191,  192,  193,  192,  194,  184,  195,  196,  197,  186,
+      188,  198,  195,  187,  189,  200,  199,  191,  190,  193,
+      202,  194,  199,  197,  198,  200,  201,  203,  196,  201,
+      204,  268,  204,  269,  272,  268,  202,  270,  273,  275,
+      203,  279,  276,  270,  278,  282,  281,  279,  281,  285,
+      269,  273,  284,  286,  272,  276,  275,  288,  290,  278,
+      348,  350,  284,  351,  352,  282,  354,  285,  355,  361,
 
-      355,  360,  350,  349,  357,  361,  354,  352,  406,  357,
-      407,  408,  410,  411,  358,  412,  410,  360,  406,  407,
-      414,  417,  414,  451,  361,  454,  452,  408,  412,  456,
-      411,  452,  453,  482,  453,  457,  483,  484,  417,  451,
-      485,  454,  483,  487,  486,  503,  482,  501,  504,  456,
-      486,  457,  506,  501,  515,  503,  522,  484,  485,  519,
-      517,  487,  520,  520,  520,  524,  524,  524,  504,  516,
-      515,  522,  506,  529,  529,  529,  529,  529,  530,  530,
-      530,  530,  530,  531,  531,  531,  531,  531,  532,  514,
-      513,  532,  533,  533,  533,  533,  533,  534,  511,  534,
+      286,  357,  348,  290,  352,  350,  360,  288,  364,  351,
+      358,  360,  354,  363,  357,  409,  358,  355,  411,  410,
+      415,  421,  413,  414,  361,  409,  413,  364,  410,  363,
+      416,  414,  455,  418,  411,  418,  456,  415,  421,  459,
+      457,  456,  457,  416,  461,  462,  487,  488,  455,  489,
+      490,  491,  492,  488,  506,  459,  508,  491,  509,  487,
+      506,  462,  511,  520,  461,  527,  508,  522,  490,  489,
+      492,  525,  525,  525,  529,  529,  529,  521,  509,  520,
+      527,  519,  511,  534,  534,  534,  534,  534,  535,  535,
+      535,  535,  535,  536,  536,  536,  536,  536,  537,  518,
 
-      534,  534,  535,  535,  536,  536,  510,  508,  505,  502,
-      497,  495,  494,  493,  490,  489,  488,  481,  479,  478,
-      477,  476,  475,  472,  467,  465,  464,  463,  462,  458,
-      455,  450,  448,  446,  445,  444,  443,  442,  441,  439,
-      438,  437,  434,  432,  430,  429,  428,  427,  426,  425,
-      423,  422,  420,  419,  418,  416,  415,  413,  409,  404,
-      403,  402,  400,  399,  397,  395,  393,  392,  391,  390,
-      388,  387,  386,  385,  384,  383,  382,  380,  379,  378,
-      374,  373,  372,  371,  370,  369,  368,  367,  365,  364,
-      363,  362,  359,  356,  353,  351,  347,  345,  342,  341,
+      516,  537,  538,  538,  538,  538,  538,  539,  515,  539,
+      539,  539,  540,  540,  541,  541,  513,  510,  507,  502,
+      500,  499,  498,  495,  494,  493,  486,  484,  483,  482,
+      481,  480,  477,  472,  470,  469,  468,  467,  463,  460,
+      458,  454,  452,  450,  449,  448,  447,  446,  445,  443,
+      442,  441,  438,  436,  434,  433,  432,  431,  430,  429,
+      427,  426,  424,  423,  422,  420,  419,  417,  412,  407,
+      406,  405,  403,  402,  400,  398,  396,  395,  394,  393,
+      391,  390,  389,  388,  387,  386,  385,  383,  382,  381,
+      377,  376,  375,  374,  373,  372,  371,  370,  368,  367,
 
-      339,  337,  336,  335,  334,  333,  332,  331,  330,  329,
-      328,  327,  326,  325,  324,  322,  321,  320,  319,  318,
-      317,  316,  315,  314,  313,  312,  311,  309,  306,  303,
-      302,  301,  299,  298,  297,  296,  294,  293,  292,  291,
-      290,  289,  287,  285,  278,  275,  273,  270,  265,  263,
-      261,  260,  259,  258,  257,  256,  255,  254,  253,  252,
-      251,  250,  249,  248,  247,  246,  245,  244,  243,  242,
-      241,  240,  239,  238,  237,  236,  235,  233,  232,  230,
-      228,  227,  226,  225,  224,  223,  222,  220,  219,  218,
-      217,  216,  215,  214,  213,  212,  211,  210,  209,  208,
+      366,  365,  362,  359,  356,  353,  349,  347,  344,  343,
+      341,  339,  338,  337,  336,  335,  334,  333,  332,  331,
+      330,  329,  328,  327,  326,  324,  323,  322,  321,  320,
+      319,  318,  317,  316,  315,  314,  313,  311,  308,  305,
+      304,  303,  301,  300,  299,  298,  296,  295,  294,  293,
+      292,  291,  289,  287,  280,  277,  274,  271,  266,  264,
+      262,  261,  260,  259,  258,  257,  256,  255,  254,  253,
+      252,  251,  250,  249,  248,  247,  246,  245,  244,  243,
+      242,  241,  240,  239,  238,  237,  236,  234,  233,  231,
+      229,  228,  227,  226,  225,  224,  223,  221,  220,  219,
 
-      207,  206,  205,  204,  183,  178,  173,  172,  171,  170,
+      218,  217,  216,  215,  214,  213,  212,  211,  210,  209,
+      208,  207,  206,  205,  183,  178,  173,  172,  171,  170,
       169,  168,  167,  166,  164,  163,  162,  161,  160,  159,
       158,  157,  156,  154,  153,  150,  147,  146,  145,  144,
       142,  141,  138,  136,  135,  133,  132,  131,  130,  129,
@@ -1001,23 +789,23 @@ static const flex_int16_t yy_chk[837] =
        81,   76,   75,   74,   72,   71,   70,   69,   68,   67,
        66,   65,   64,   61,   60,   56,   53,   52,   51,   49,
        48,   47,   46,   45,   43,   42,   40,   39,   38,   37,
-       36,   35,   33,   32,   29,  528,  528,  528,  528,  528,
 
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528,  528,  528,  528,  528,
-      528,  528,  528,  528,  528,  528
+       36,   35,   33,   32,   29,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533,  533,  533,  533,  533,
+      533,  533,  533,  533,  533,  533
     } ;
 
 /* Table of booleans, true if rule could match eol. */
-static const flex_int32_t yy_rule_can_match_eol[104] =
+static yyconst flex_int32_t yy_rule_can_match_eol[105] =
     {   0,
 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 
-    0, 0, 0, 0,     };
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 
+    0, 0, 0, 0, 0,     };
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -1041,10 +829,10 @@ static const flex_int32_t yy_rule_can_match_eol[104] =
 #define YY_USER_INIT yycolumn = 0; yylineno = 0;
 
 int identstate = 0;
-#line 1044 "conffile.yy.c"
 #define YY_NO_INPUT 1
 
-#line 1047 "conffile.yy.c"
+
+#line 836 "conffile.yy.c"
 
 #define INITIAL 0
 #define cl 1
@@ -1086,8 +874,8 @@ struct yyguts_t
     size_t yy_buffer_stack_max; /**< capacity of stack. */
     YY_BUFFER_STATE * yy_buffer_stack; /**< Stack as an array. */
     char yy_hold_char;
-    int yy_n_chars;
-    int yyleng_r;
+    yy_size_t yy_n_chars;
+    yy_size_t yyleng_r;
     char *yy_c_buf_p;
     int yy_init;
     int yy_start;
@@ -1109,52 +897,48 @@ struct yyguts_t
 
     }; /* end struct yyguts_t */
 
-static int yy_init_globals ( yyscan_t yyscanner );
+static int yy_init_globals (yyscan_t yyscanner );
 
     /* This must go here because YYSTYPE and YYLTYPE are included
      * from bison output in section 1.*/
     #    define yylval yyg->yylval_r
     
-int yylex_init (yyscan_t* scanner);
+int router_yylex_init (yyscan_t* scanner);
 
-int yylex_init_extra ( YY_EXTRA_TYPE user_defined, yyscan_t* scanner);
+int router_yylex_init_extra (YY_EXTRA_TYPE user_defined,yyscan_t* scanner);
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy ( yyscan_t yyscanner );
+int router_yylex_destroy (yyscan_t yyscanner );
 
-int yyget_debug ( yyscan_t yyscanner );
+int router_yyget_debug (yyscan_t yyscanner );
 
-void yyset_debug ( int debug_flag , yyscan_t yyscanner );
+void router_yyset_debug (int debug_flag ,yyscan_t yyscanner );
 
-YY_EXTRA_TYPE yyget_extra ( yyscan_t yyscanner );
+YY_EXTRA_TYPE router_yyget_extra (yyscan_t yyscanner );
 
-void yyset_extra ( YY_EXTRA_TYPE user_defined , yyscan_t yyscanner );
+void router_yyset_extra (YY_EXTRA_TYPE user_defined ,yyscan_t yyscanner );
 
-FILE *yyget_in ( yyscan_t yyscanner );
+FILE *router_yyget_in (yyscan_t yyscanner );
 
-void yyset_in  ( FILE * _in_str , yyscan_t yyscanner );
+void router_yyset_in  (FILE * in_str ,yyscan_t yyscanner );
 
-FILE *yyget_out ( yyscan_t yyscanner );
+FILE *router_yyget_out (yyscan_t yyscanner );
 
-void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
+void router_yyset_out  (FILE * out_str ,yyscan_t yyscanner );
 
-			int yyget_leng ( yyscan_t yyscanner );
+yy_size_t router_yyget_leng (yyscan_t yyscanner );
 
-char *yyget_text ( yyscan_t yyscanner );
+char *router_yyget_text (yyscan_t yyscanner );
 
-int yyget_lineno ( yyscan_t yyscanner );
+int router_yyget_lineno (yyscan_t yyscanner );
 
-void yyset_lineno ( int _line_number , yyscan_t yyscanner );
+void router_yyset_lineno (int line_number ,yyscan_t yyscanner );
 
-int yyget_column  ( yyscan_t yyscanner );
+YYSTYPE * router_yyget_lval (yyscan_t yyscanner );
 
-void yyset_column ( int _column_no , yyscan_t yyscanner );
-
-YYSTYPE * yyget_lval ( yyscan_t yyscanner );
-
-void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
+void router_yyset_lval (YYSTYPE * yylval_param ,yyscan_t yyscanner );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -1162,41 +946,33 @@ void yyset_lval ( YYSTYPE * yylval_param , yyscan_t yyscanner );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap ( yyscan_t yyscanner );
+extern "C" int router_yywrap (yyscan_t yyscanner );
 #else
-extern int yywrap ( yyscan_t yyscanner );
+extern int router_yywrap (yyscan_t yyscanner );
 #endif
-#endif
-
-#ifndef YY_NO_UNPUT
-    
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy ( char *, const char *, int , yyscan_t yyscanner);
+static void yy_flex_strncpy (char *,yyconst char *,int ,yyscan_t yyscanner);
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen ( const char * , yyscan_t yyscanner);
+static int yy_flex_strlen (yyconst char * ,yyscan_t yyscanner);
 #endif
 
 #ifndef YY_NO_INPUT
+
 #ifdef __cplusplus
-static int yyinput ( yyscan_t yyscanner );
+static int yyinput (yyscan_t yyscanner );
 #else
-static int input ( yyscan_t yyscanner );
+static int input (yyscan_t yyscanner );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
-#ifdef __ia64__
-/* On IA-64, the buffer size is 16k, not 8k */
-#define YY_READ_BUF_SIZE 16384
-#else
 #define YY_READ_BUF_SIZE 8192
-#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -1204,7 +980,7 @@ static int input ( yyscan_t yyscanner );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
+#define ECHO fwrite( yytext, yyleng, 1, yyout )
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -1215,7 +991,7 @@ static int input ( yyscan_t yyscanner );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		int n; \
+		yy_size_t n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -1228,7 +1004,7 @@ static int input ( yyscan_t yyscanner );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
+		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -1269,10 +1045,10 @@ static int input ( yyscan_t yyscanner );
 #ifndef YY_DECL
 #define YY_DECL_IS_OURS 1
 
-extern int yylex \
-               (YYSTYPE * yylval_param , yyscan_t yyscanner);
+extern int router_yylex \
+               (YYSTYPE * yylval_param ,yyscan_t yyscanner);
 
-#define YY_DECL int yylex \
+#define YY_DECL int router_yylex \
                (YYSTYPE * yylval_param , yyscan_t yyscanner)
 #endif /* !YY_DECL */
 
@@ -1285,7 +1061,7 @@ extern int yylex \
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK /*LINTED*/break;
+#define YY_BREAK break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -1295,10 +1071,18 @@ extern int yylex \
  */
 YY_DECL
 {
-	yy_state_type yy_current_state;
-	char *yy_cp, *yy_bp;
-	int yy_act;
+	register yy_state_type yy_current_state;
+	register char *yy_cp, *yy_bp;
+	register int yy_act;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
+
+#line 31 "conffile.l"
+
+
+	char string_buf[1024];
+	char *strbuf = NULL;
+
+#line 1086 "conffile.yy.c"
 
     yylval = yylval_param;
 
@@ -1320,25 +1104,15 @@ YY_DECL
 			yyout = stdout;
 
 		if ( ! YY_CURRENT_BUFFER ) {
-			yyensure_buffer_stack (yyscanner);
+			router_yyensure_buffer_stack (yyscanner);
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
+				router_yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
 		}
 
-		yy_load_buffer_state( yyscanner );
+		router_yy_load_buffer_state(yyscanner );
 		}
 
-	{
-#line 31 "conffile.l"
-
-
-#line 34 "conffile.l"
-	char string_buf[1024];
-	char *strbuf = NULL;
-
-#line 1339 "conffile.yy.c"
-
-	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
+	while ( 1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = yyg->yy_c_buf_p;
 
@@ -1354,7 +1128,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
+			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
 			if ( yy_accept[yy_current_state] )
 				{
 				yyg->yy_last_accepting_state = yy_current_state;
@@ -1363,13 +1137,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 529 )
-					yy_c = yy_meta[yy_c];
+				if ( yy_current_state >= 534 )
+					yy_c = yy_meta[(unsigned int) yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 			++yy_cp;
 			}
-		while ( yy_base[yy_current_state] != 796 );
+		while ( yy_base[yy_current_state] != 806 );
 
 yy_find_action:
 		yy_act = yy_accept[yy_current_state];
@@ -1384,10 +1158,10 @@ yy_find_action:
 
 		if ( yy_act != YY_END_OF_BUFFER && yy_rule_can_match_eol[yy_act] )
 			{
-			int yyl;
+			yy_size_t yyl;
 			for ( yyl = 0; yyl < yyleng; ++yyl )
 				if ( yytext[yyl] == '\n' )
-					
+					   
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -1407,7 +1181,7 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 37 "conffile.l"
+#line 36 "conffile.l"
 {
 						identstate = cl;
 						BEGIN(idcl);
@@ -1416,7 +1190,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 42 "conffile.l"
+#line 41 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1425,7 +1199,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 47 "conffile.l"
+#line 46 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1434,7 +1208,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 52 "conffile.l"
+#line 51 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1443,12 +1217,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 57 "conffile.l"
+#line 56 "conffile.l"
 return crUSEALL;
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 58 "conffile.l"
+#line 57 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1457,7 +1231,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 63 "conffile.l"
+#line 62 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1466,7 +1240,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 68 "conffile.l"
+#line 67 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1475,12 +1249,12 @@ YY_RULE_SETUP
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 73 "conffile.l"
+#line 72 "conffile.l"
 return crREPLICATION;
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 74 "conffile.l"
+#line 73 "conffile.l"
 {
 						identstate = idcl;
 						BEGIN(idcl);
@@ -1489,60 +1263,65 @@ YY_RULE_SETUP
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 79 "conffile.l"
+#line 78 "conffile.l"
 return crIP;
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 80 "conffile.l"
+#line 79 "conffile.l"
 return crPROTO;
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 81 "conffile.l"
+#line 80 "conffile.l"
 return crUDP;
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 82 "conffile.l"
+#line 81 "conffile.l"
 return crTCP;
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 83 "conffile.l"
+#line 82 "conffile.l"
 return crTYPE;
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 84 "conffile.l"
+#line 83 "conffile.l"
 return crLINEMODE;
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
+#line 84 "conffile.l"
+return crSYSLOGMODE;
+	YY_BREAK
+case 18:
+YY_RULE_SETUP
 #line 85 "conffile.l"
 return crTRANSPORT;
 	YY_BREAK
-case 18:
+case 19:
 YY_RULE_SETUP
 #line 86 "conffile.l"
 return crGZIP;
 	YY_BREAK
-case 19:
+case 20:
 YY_RULE_SETUP
 #line 87 "conffile.l"
 return crLZ4;
 	YY_BREAK
-case 20:
+case 21:
 YY_RULE_SETUP
 #line 88 "conffile.l"
 return crSSL;
 	YY_BREAK
-case 21:
+case 22:
 YY_RULE_SETUP
 #line 89 "conffile.l"
 return '=';
 	YY_BREAK
-case 22:
+case 23:
 YY_RULE_SETUP
 #line 91 "conffile.l"
 {
@@ -1551,12 +1330,12 @@ YY_RULE_SETUP
 						return crMATCH;
 					}
 	YY_BREAK
-case 23:
+case 24:
 YY_RULE_SETUP
 #line 96 "conffile.l"
 return '*';
 	YY_BREAK
-case 24:
+case 25:
 YY_RULE_SETUP
 #line 97 "conffile.l"
 {
@@ -1565,22 +1344,22 @@ YY_RULE_SETUP
 						return crVALIDATE;
 					}
 	YY_BREAK
-case 25:
+case 26:
 YY_RULE_SETUP
 #line 102 "conffile.l"
 return crELSE;
 	YY_BREAK
-case 26:
+case 27:
 YY_RULE_SETUP
 #line 103 "conffile.l"
 return crLOG;
 	YY_BREAK
-case 27:
+case 28:
 YY_RULE_SETUP
 #line 104 "conffile.l"
 return crDROP;
 	YY_BREAK
-case 28:
+case 29:
 YY_RULE_SETUP
 #line 105 "conffile.l"
 {
@@ -1588,7 +1367,7 @@ YY_RULE_SETUP
 						return crROUTE;
 					}
 	YY_BREAK
-case 29:
+case 30:
 YY_RULE_SETUP
 #line 109 "conffile.l"
 {	
@@ -1597,7 +1376,7 @@ YY_RULE_SETUP
 						return crUSING;
 					}
 	YY_BREAK
-case 30:
+case 31:
 YY_RULE_SETUP
 #line 114 "conffile.l"
 {
@@ -1605,7 +1384,7 @@ YY_RULE_SETUP
 						return crSEND;
 					}
 	YY_BREAK
-case 31:
+case 32:
 YY_RULE_SETUP
 #line 118 "conffile.l"
 {
@@ -1614,17 +1393,17 @@ YY_RULE_SETUP
 						return crTO;
 					}
 	YY_BREAK
-case 32:
+case 33:
 YY_RULE_SETUP
 #line 123 "conffile.l"
 return crBLACKHOLE;
 	YY_BREAK
-case 33:
+case 34:
 YY_RULE_SETUP
 #line 124 "conffile.l"
 return crSTOP;
 	YY_BREAK
-case 34:
+case 35:
 YY_RULE_SETUP
 #line 126 "conffile.l"
 {
@@ -1633,7 +1412,7 @@ YY_RULE_SETUP
 						return crREWRITE;
 					}
 	YY_BREAK
-case 35:
+case 36:
 YY_RULE_SETUP
 #line 131 "conffile.l"
 {
@@ -1642,7 +1421,7 @@ YY_RULE_SETUP
 						return crINTO;
 					}
 	YY_BREAK
-case 36:
+case 37:
 YY_RULE_SETUP
 #line 137 "conffile.l"
 {
@@ -1651,7 +1430,7 @@ YY_RULE_SETUP
 						return crAGGREGATE;
 					}
 	YY_BREAK
-case 37:
+case 38:
 YY_RULE_SETUP
 #line 142 "conffile.l"
 {
@@ -1659,117 +1438,117 @@ YY_RULE_SETUP
 						return crEVERY;
 					}
 	YY_BREAK
-case 38:
+case 39:
 YY_RULE_SETUP
 #line 146 "conffile.l"
 return crSECONDS;
 	YY_BREAK
-case 39:
+case 40:
 YY_RULE_SETUP
 #line 147 "conffile.l"
 return crEXPIRE;
 	YY_BREAK
-case 40:
+case 41:
 YY_RULE_SETUP
 #line 148 "conffile.l"
 return crAFTER;
 	YY_BREAK
-case 41:
+case 42:
 YY_RULE_SETUP
 #line 149 "conffile.l"
 return crTIMESTAMP;
 	YY_BREAK
-case 42:
+case 43:
 YY_RULE_SETUP
 #line 150 "conffile.l"
 return crAT;
 	YY_BREAK
-case 43:
+case 44:
 YY_RULE_SETUP
 #line 151 "conffile.l"
 return crSTART;
 	YY_BREAK
-case 44:
+case 45:
 YY_RULE_SETUP
 #line 152 "conffile.l"
 return crMIDDLE;
 	YY_BREAK
-case 45:
+case 46:
 YY_RULE_SETUP
 #line 153 "conffile.l"
 return crEND;
 	YY_BREAK
-case 46:
+case 47:
 YY_RULE_SETUP
 #line 154 "conffile.l"
 return crOF;
 	YY_BREAK
-case 47:
+case 48:
 YY_RULE_SETUP
 #line 155 "conffile.l"
 return crBUCKET;
 	YY_BREAK
-case 48:
+case 49:
 YY_RULE_SETUP
 #line 156 "conffile.l"
 return crCOMPUTE;
 	YY_BREAK
-case 49:
+case 50:
 YY_RULE_SETUP
 #line 157 "conffile.l"
 return crSUM;
 	YY_BREAK
-case 50:
+case 51:
 YY_RULE_SETUP
 #line 158 "conffile.l"
 return crSUM;
 	YY_BREAK
-case 51:
+case 52:
 YY_RULE_SETUP
 #line 159 "conffile.l"
 return crCOUNT;
 	YY_BREAK
-case 52:
+case 53:
 YY_RULE_SETUP
 #line 160 "conffile.l"
 return crCOUNT;
 	YY_BREAK
-case 53:
+case 54:
 YY_RULE_SETUP
 #line 161 "conffile.l"
 return crMAX;
 	YY_BREAK
-case 54:
+case 55:
 YY_RULE_SETUP
 #line 162 "conffile.l"
 return crMAX;
 	YY_BREAK
-case 55:
+case 56:
 YY_RULE_SETUP
 #line 163 "conffile.l"
 return crMIN;
 	YY_BREAK
-case 56:
+case 57:
 YY_RULE_SETUP
 #line 164 "conffile.l"
 return crMIN;
 	YY_BREAK
-case 57:
+case 58:
 YY_RULE_SETUP
 #line 165 "conffile.l"
 return crAVERAGE;
 	YY_BREAK
-case 58:
+case 59:
 YY_RULE_SETUP
 #line 166 "conffile.l"
 return crAVERAGE;
 	YY_BREAK
-case 59:
+case 60:
 YY_RULE_SETUP
 #line 167 "conffile.l"
 return crMEDIAN;
 	YY_BREAK
-case 60:
+case 61:
 YY_RULE_SETUP
 #line 168 "conffile.l"
 {
@@ -1778,22 +1557,22 @@ YY_RULE_SETUP
 						return crPERCENTILE;
 					}
 	YY_BREAK
-case 61:
+case 62:
 YY_RULE_SETUP
 #line 173 "conffile.l"
 return crVARIANCE;
 	YY_BREAK
-case 62:
+case 63:
 YY_RULE_SETUP
 #line 174 "conffile.l"
 return crSTDDEV;
 	YY_BREAK
-case 63:
+case 64:
 YY_RULE_SETUP
 #line 175 "conffile.l"
 return crWRITE;
 	YY_BREAK
-case 64:
+case 65:
 YY_RULE_SETUP
 #line 176 "conffile.l"
 {
@@ -1802,7 +1581,7 @@ YY_RULE_SETUP
 						return crTO;
 					}
 	YY_BREAK
-case 65:
+case 66:
 YY_RULE_SETUP
 #line 181 "conffile.l"
 {
@@ -1811,7 +1590,7 @@ YY_RULE_SETUP
 						return crSEND;
 					}
 	YY_BREAK
-case 66:
+case 67:
 YY_RULE_SETUP
 #line 187 "conffile.l"
 {
@@ -1819,7 +1598,7 @@ YY_RULE_SETUP
 						return crSEND;
 					}
 	YY_BREAK
-case 67:
+case 68:
 YY_RULE_SETUP
 #line 191 "conffile.l"
 {
@@ -1828,7 +1607,7 @@ YY_RULE_SETUP
 						return crSTATISTICS;
 					}
 	YY_BREAK
-case 68:
+case 69:
 YY_RULE_SETUP
 #line 197 "conffile.l"
 {
@@ -1836,47 +1615,47 @@ YY_RULE_SETUP
 						return crSTATISTICS;
 					}
 	YY_BREAK
-case 69:
+case 70:
 YY_RULE_SETUP
 #line 201 "conffile.l"
 return crSUBMIT;
 	YY_BREAK
-case 70:
+case 71:
 YY_RULE_SETUP
 #line 202 "conffile.l"
 return crEVERY;
 	YY_BREAK
-case 71:
+case 72:
 YY_RULE_SETUP
 #line 203 "conffile.l"
 return crSECONDS;
 	YY_BREAK
-case 72:
+case 73:
 YY_RULE_SETUP
 #line 204 "conffile.l"
 return crRESET;
 	YY_BREAK
-case 73:
+case 74:
 YY_RULE_SETUP
 #line 205 "conffile.l"
 return crCOUNTERS;
 	YY_BREAK
-case 74:
+case 75:
 YY_RULE_SETUP
 #line 206 "conffile.l"
 return crAFTER;
 	YY_BREAK
-case 75:
+case 76:
 YY_RULE_SETUP
 #line 207 "conffile.l"
 return crINTERVAL;
 	YY_BREAK
-case 76:
+case 77:
 YY_RULE_SETUP
 #line 208 "conffile.l"
 return crPREFIX;
 	YY_BREAK
-case 77:
+case 78:
 YY_RULE_SETUP
 #line 209 "conffile.l"
 {
@@ -1885,7 +1664,7 @@ YY_RULE_SETUP
 						return crWITH;
 					}
 	YY_BREAK
-case 78:
+case 79:
 YY_RULE_SETUP
 #line 214 "conffile.l"
 {
@@ -1894,7 +1673,7 @@ YY_RULE_SETUP
 						return crSEND;
 					}
 	YY_BREAK
-case 79:
+case 80:
 YY_RULE_SETUP
 #line 220 "conffile.l"
 {
@@ -1902,12 +1681,12 @@ YY_RULE_SETUP
 						return crLISTEN;
 					}
 	YY_BREAK
-case 80:
+case 81:
 YY_RULE_SETUP
 #line 224 "conffile.l"
 return crTYPE;
 	YY_BREAK
-case 81:
+case 82:
 YY_RULE_SETUP
 #line 225 "conffile.l"
 {
@@ -1916,12 +1695,12 @@ YY_RULE_SETUP
 						return crLINEMODE;
 					}
 	YY_BREAK
-case 82:
+case 83:
 YY_RULE_SETUP
 #line 230 "conffile.l"
 return crTRANSPORT;
 	YY_BREAK
-case 83:
+case 84:
 YY_RULE_SETUP
 #line 231 "conffile.l"
 {
@@ -1930,7 +1709,7 @@ YY_RULE_SETUP
 						return crGZIP;
 					}
 	YY_BREAK
-case 84:
+case 85:
 YY_RULE_SETUP
 #line 236 "conffile.l"
 {
@@ -1939,7 +1718,7 @@ YY_RULE_SETUP
 						return crLZ4;
 					}
 	YY_BREAK
-case 85:
+case 86:
 YY_RULE_SETUP
 #line 241 "conffile.l"
 {
@@ -1948,7 +1727,7 @@ YY_RULE_SETUP
 						return crSSL;
 					}
 	YY_BREAK
-case 86:
+case 87:
 YY_RULE_SETUP
 #line 246 "conffile.l"
 {
@@ -1956,7 +1735,7 @@ YY_RULE_SETUP
 						return crPROTO;
 					}
 	YY_BREAK
-case 87:
+case 88:
 YY_RULE_SETUP
 #line 250 "conffile.l"
 {
@@ -1965,7 +1744,7 @@ YY_RULE_SETUP
 						return crUDP;
 					}
 	YY_BREAK
-case 88:
+case 89:
 YY_RULE_SETUP
 #line 255 "conffile.l"
 {
@@ -1974,7 +1753,7 @@ YY_RULE_SETUP
 						return crTCP;
 					}
 	YY_BREAK
-case 89:
+case 90:
 YY_RULE_SETUP
 #line 260 "conffile.l"
 {
@@ -1983,7 +1762,7 @@ YY_RULE_SETUP
 						return crUNIX;
 					}
 	YY_BREAK
-case 90:
+case 91:
 YY_RULE_SETUP
 #line 266 "conffile.l"
 {
@@ -1993,7 +1772,7 @@ YY_RULE_SETUP
 					}
 	YY_BREAK
 /* handle quoted strings */
-case 91:
+case 92:
 YY_RULE_SETUP
 #line 273 "conffile.l"
 {
@@ -2002,7 +1781,7 @@ YY_RULE_SETUP
 					}
 	YY_BREAK
 
-case 92:
+case 93:
 YY_RULE_SETUP
 #line 278 "conffile.l"
 {
@@ -2017,8 +1796,8 @@ YY_RULE_SETUP
 						return crSTRING;
 					}
 	YY_BREAK
-case 93:
-/* rule 93 can match eol */
+case 94:
+/* rule 94 can match eol */
 YY_RULE_SETUP
 #line 289 "conffile.l"
 {
@@ -2035,7 +1814,7 @@ case YY_STATE_EOF(qu):
 						yyterminate();
 					}
 	YY_BREAK
-case 94:
+case 95:
 YY_RULE_SETUP
 #line 299 "conffile.l"
 {
@@ -2047,7 +1826,7 @@ YY_RULE_SETUP
 						}
 					}
 	YY_BREAK
-case 95:
+case 96:
 YY_RULE_SETUP
 #line 307 "conffile.l"
 {
@@ -2063,8 +1842,8 @@ YY_RULE_SETUP
 					}
 	YY_BREAK
 
-case 96:
-/* rule 96 can match eol */
+case 97:
+/* rule 97 can match eol */
 YY_RULE_SETUP
 #line 320 "conffile.l"
 {
@@ -2076,18 +1855,18 @@ YY_RULE_SETUP
 						;
 					}
 	YY_BREAK
-case 97:
+case 98:
 YY_RULE_SETUP
 #line 329 "conffile.l"
 ; /* whitespace */
 	YY_BREAK
-case 98:
-/* rule 98 can match eol */
+case 99:
+/* rule 99 can match eol */
 YY_RULE_SETUP
 #line 330 "conffile.l"
 yycolumn = 0;
 	YY_BREAK
-case 99:
+case 100:
 YY_RULE_SETUP
 #line 331 "conffile.l"
 {
@@ -2095,7 +1874,7 @@ YY_RULE_SETUP
 						return crINTVAL;
 					}
 	YY_BREAK
-case 100:
+case 101:
 YY_RULE_SETUP
 #line 335 "conffile.l"
 {
@@ -2104,12 +1883,12 @@ YY_RULE_SETUP
 						return crSTRING;
 					}
 	YY_BREAK
-case 101:
+case 102:
 YY_RULE_SETUP
 #line 340 "conffile.l"
 { BEGIN(INITIAL); return ';'; }
 	YY_BREAK
-case 102:
+case 103:
 YY_RULE_SETUP
 #line 341 "conffile.l"
 {
@@ -2119,12 +1898,12 @@ YY_RULE_SETUP
 						return crUNEXPECTED;
 					}
 	YY_BREAK
-case 103:
+case 104:
 YY_RULE_SETUP
 #line 348 "conffile.l"
 ECHO;
 	YY_BREAK
-#line 2127 "conffile.yy.c"
+#line 1907 "conffile.yy.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(cl):
 case YY_STATE_EOF(ma):
@@ -2154,7 +1933,7 @@ case YY_STATE_EOF(idli):
 			/* We're scanning a new file or input source.  It's
 			 * possible that this happened because the user
 			 * just pointed yyin at a new source and called
-			 * yylex().  If so, then we have to assure
+			 * router_yylex().  If so, then we have to assure
 			 * consistency between YY_CURRENT_BUFFER and our
 			 * globals.  Here is the right place to do so, because
 			 * this is the first action (other than possibly a
@@ -2214,7 +1993,7 @@ case YY_STATE_EOF(idli):
 				{
 				yyg->yy_did_buffer_switch_on_eof = 0;
 
-				if ( yywrap( yyscanner ) )
+				if ( router_yywrap(yyscanner ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -2267,8 +2046,7 @@ case YY_STATE_EOF(idli):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
-	} /* end of user's declarations */
-} /* end of yylex */
+} /* end of router_yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
  *
@@ -2280,9 +2058,9 @@ case YY_STATE_EOF(idli):
 static int yy_get_next_buffer (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	char *source = yyg->yytext_ptr;
-	int number_to_move, i;
+	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	register char *source = yyg->yytext_ptr;
+	register int number_to_move, i;
 	int ret_val;
 
 	if ( yyg->yy_c_buf_p > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[yyg->yy_n_chars + 1] )
@@ -2311,7 +2089,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr - 1);
+	number_to_move = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr) - 1;
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -2324,21 +2102,21 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 	else
 		{
-			int num_to_read =
+			yy_size_t num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
 
 			int yy_c_buf_p_offset =
 				(int) (yyg->yy_c_buf_p - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				int new_size = b->yy_buf_size * 2;
+				yy_size_t new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -2347,12 +2125,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc( (void *) b->yy_ch_buf,
-							 (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
+					router_yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2 ,yyscanner );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = NULL;
+				b->yy_ch_buf = 0;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -2380,7 +2157,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart( yyin  , yyscanner);
+			router_yyrestart(yyin  ,yyscanner);
 			}
 
 		else
@@ -2394,15 +2171,12 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yy_size_t) (yyg->yy_n_chars + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
-			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size , yyscanner );
+		yy_size_t new_size = yyg->yy_n_chars + number_to_move + (yyg->yy_n_chars >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) router_yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size ,yyscanner );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
-		/* "- 2" to take care of EOB's */
-		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	yyg->yy_n_chars += number_to_move;
@@ -2418,15 +2192,15 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
     static yy_state_type yy_get_previous_state (yyscan_t yyscanner)
 {
-	yy_state_type yy_current_state;
-	char *yy_cp;
+	register yy_state_type yy_current_state;
+	register char *yy_cp;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	yy_current_state = yyg->yy_start;
 
 	for ( yy_cp = yyg->yytext_ptr + YY_MORE_ADJ; yy_cp < yyg->yy_c_buf_p; ++yy_cp )
 		{
-		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			yyg->yy_last_accepting_state = yy_current_state;
@@ -2435,10 +2209,10 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 529 )
-				yy_c = yy_meta[yy_c];
+			if ( yy_current_state >= 534 )
+				yy_c = yy_meta[(unsigned int) yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 		}
 
 	return yy_current_state;
@@ -2451,11 +2225,11 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state , yyscan_t yyscanner)
 {
-	int yy_is_jam;
+	register int yy_is_jam;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner; /* This var may be unused depending upon options. */
-	char *yy_cp = yyg->yy_c_buf_p;
+	register char *yy_cp = yyg->yy_c_buf_p;
 
-	YY_CHAR yy_c = 1;
+	register YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		yyg->yy_last_accepting_state = yy_current_state;
@@ -2464,19 +2238,14 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 529 )
-			yy_c = yy_meta[yy_c];
+		if ( yy_current_state >= 534 )
+			yy_c = yy_meta[(unsigned int) yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
-	yy_is_jam = (yy_current_state == 528);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_is_jam = (yy_current_state == 533);
 
-	(void)yyg;
 	return yy_is_jam ? 0 : yy_current_state;
 }
-
-#ifndef YY_NO_UNPUT
-
-#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -2503,7 +2272,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 
 		else
 			{ /* need more input */
-			int offset = (int) (yyg->yy_c_buf_p - yyg->yytext_ptr);
+			yy_size_t offset = yyg->yy_c_buf_p - yyg->yytext_ptr;
 			++yyg->yy_c_buf_p;
 
 			switch ( yy_get_next_buffer( yyscanner ) )
@@ -2520,13 +2289,13 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart( yyin , yyscanner);
+					router_yyrestart(yyin ,yyscanner);
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( yyscanner ) )
+					if ( router_yywrap(yyscanner ) )
 						return 0;
 
 					if ( ! yyg->yy_did_buffer_switch_on_eof )
@@ -2550,7 +2319,7 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 	yyg->yy_hold_char = *++yyg->yy_c_buf_p;
 
 	if ( c == '\n' )
-		
+		   
     do{ yylineno++;
         yycolumn=0;
     }while(0)
@@ -2565,34 +2334,34 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @note This function does not reset the start condition to @c INITIAL .
  */
-    void yyrestart  (FILE * input_file , yyscan_t yyscanner)
+    void router_yyrestart  (FILE * input_file , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	if ( ! YY_CURRENT_BUFFER ){
-        yyensure_buffer_stack (yyscanner);
+        router_yyensure_buffer_stack (yyscanner);
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer( yyin, YY_BUF_SIZE , yyscanner);
+            router_yy_create_buffer(yyin,YY_BUF_SIZE ,yyscanner);
 	}
 
-	yy_init_buffer( YY_CURRENT_BUFFER, input_file , yyscanner);
-	yy_load_buffer_state( yyscanner );
+	router_yy_init_buffer(YY_CURRENT_BUFFER,input_file ,yyscanner);
+	router_yy_load_buffer_state(yyscanner );
 }
 
 /** Switch to a different input buffer.
  * @param new_buffer The new input buffer.
  * @param yyscanner The scanner object.
  */
-    void yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
+    void router_yy_switch_to_buffer  (YY_BUFFER_STATE  new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
 	/* TODO. We should be able to replace this entire function body
 	 * with
-	 *		yypop_buffer_state();
-	 *		yypush_buffer_state(new_buffer);
+	 *		router_yypop_buffer_state();
+	 *		router_yypush_buffer_state(new_buffer);
      */
-	yyensure_buffer_stack (yyscanner);
+	router_yyensure_buffer_stack (yyscanner);
 	if ( YY_CURRENT_BUFFER == new_buffer )
 		return;
 
@@ -2605,17 +2374,17 @@ static int yy_get_next_buffer (yyscan_t yyscanner)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( yyscanner );
+	router_yy_load_buffer_state(yyscanner );
 
 	/* We don't actually know whether we did this switch during
-	 * EOF (yywrap()) processing, but the only time this flag
-	 * is looked at is after yywrap() is called, so it's safe
+	 * EOF (router_yywrap()) processing, but the only time this flag
+	 * is looked at is after router_yywrap() is called, so it's safe
 	 * to go ahead and always set it.
 	 */
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
-static void yy_load_buffer_state  (yyscan_t yyscanner)
+static void router_yy_load_buffer_state  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	yyg->yy_n_chars = YY_CURRENT_BUFFER_LVALUE->yy_n_chars;
@@ -2630,35 +2399,35 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  * @return the allocated buffer state.
  */
-    YY_BUFFER_STATE yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
+    YY_BUFFER_STATE router_yy_create_buffer  (FILE * file, int  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
+	b = (YY_BUFFER_STATE) router_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in router_yy_create_buffer()" );
 
 	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2) , yyscanner );
+	b->yy_ch_buf = (char *) router_yyalloc(b->yy_buf_size + 2 ,yyscanner );
 	if ( ! b->yy_ch_buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in router_yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer( b, file , yyscanner);
+	router_yy_init_buffer(b,file ,yyscanner);
 
 	return b;
 }
 
 /** Destroy the buffer.
- * @param b a buffer created with yy_create_buffer()
+ * @param b a buffer created with router_yy_create_buffer()
  * @param yyscanner The scanner object.
  */
-    void yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void router_yy_delete_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
@@ -2669,28 +2438,32 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree( (void *) b->yy_ch_buf , yyscanner );
+		router_yyfree((void *) b->yy_ch_buf ,yyscanner );
 
-	yyfree( (void *) b , yyscanner );
+	router_yyfree((void *) b ,yyscanner );
 }
 
+#ifndef __cplusplus
+extern int isatty (int );
+#endif /* __cplusplus */
+    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
- * such as during a yyrestart() or at EOF.
+ * such as during a router_yyrestart() or at EOF.
  */
-    static void yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
+    static void router_yy_init_buffer  (YY_BUFFER_STATE  b, FILE * file , yyscan_t yyscanner)
 
 {
 	int oerrno = errno;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
-	yy_flush_buffer( b , yyscanner);
+	router_yy_flush_buffer(b ,yyscanner);
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
 
-    /* If b is the current buffer, then yy_init_buffer was _probably_
-     * called from yyrestart() or through yy_get_next_buffer.
+    /* If b is the current buffer, then router_yy_init_buffer was _probably_
+     * called from router_yyrestart() or through yy_get_next_buffer.
      * In that case, we don't want to reset the lineno or column.
      */
     if (b != YY_CURRENT_BUFFER){
@@ -2707,7 +2480,7 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
  * @param b the buffer state to be flushed, usually @c YY_CURRENT_BUFFER.
  * @param yyscanner The scanner object.
  */
-    void yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
+    void router_yy_flush_buffer (YY_BUFFER_STATE  b , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if ( ! b )
@@ -2728,7 +2501,7 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( yyscanner );
+		router_yy_load_buffer_state(yyscanner );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2737,15 +2510,15 @@ static void yy_load_buffer_state  (yyscan_t yyscanner)
  *  @param new_buffer The new state.
  *  @param yyscanner The scanner object.
  */
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
+void router_yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (new_buffer == NULL)
 		return;
 
-	yyensure_buffer_stack(yyscanner);
+	router_yyensure_buffer_stack(yyscanner);
 
-	/* This block is copied from yy_switch_to_buffer. */
+	/* This block is copied from router_yy_switch_to_buffer. */
 	if ( YY_CURRENT_BUFFER )
 		{
 		/* Flush out information for old buffer. */
@@ -2759,8 +2532,8 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
 		yyg->yy_buffer_stack_top++;
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
-	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( yyscanner );
+	/* copied from router_yy_switch_to_buffer. */
+	router_yy_load_buffer_state(yyscanner );
 	yyg->yy_did_buffer_switch_on_eof = 1;
 }
 
@@ -2768,19 +2541,19 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer , yyscan_t yyscanner)
  *  The next element becomes the new top.
  *  @param yyscanner The scanner object.
  */
-void yypop_buffer_state (yyscan_t yyscanner)
+void router_yypop_buffer_state (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 	if (!YY_CURRENT_BUFFER)
 		return;
 
-	yy_delete_buffer(YY_CURRENT_BUFFER , yyscanner);
+	router_yy_delete_buffer(YY_CURRENT_BUFFER ,yyscanner);
 	YY_CURRENT_BUFFER_LVALUE = NULL;
 	if (yyg->yy_buffer_stack_top > 0)
 		--yyg->yy_buffer_stack_top;
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( yyscanner );
+		router_yy_load_buffer_state(yyscanner );
 		yyg->yy_did_buffer_switch_on_eof = 1;
 	}
 }
@@ -2788,7 +2561,7 @@ void yypop_buffer_state (yyscan_t yyscanner)
 /* Allocates the stack if it does not exist.
  *  Guarantees space for at least one push.
  */
-static void yyensure_buffer_stack (yyscan_t yyscanner)
+static void router_yyensure_buffer_stack (yyscan_t yyscanner)
 {
 	yy_size_t num_to_alloc;
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
@@ -2799,15 +2572,15 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyalloc
+		num_to_alloc = 1;
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)router_yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-
+			YY_FATAL_ERROR( "out of dynamic memory in router_yyensure_buffer_stack()" );
+								  
 		memset(yyg->yy_buffer_stack, 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-
+				
 		yyg->yy_buffer_stack_max = num_to_alloc;
 		yyg->yy_buffer_stack_top = 0;
 		return;
@@ -2816,15 +2589,15 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
 	if (yyg->yy_buffer_stack_top >= (yyg->yy_buffer_stack_max) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		yy_size_t grow_size = 8 /* arbitrary grow size */;
+		int grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = yyg->yy_buffer_stack_max + grow_size;
-		yyg->yy_buffer_stack = (struct yy_buffer_state**)yyrealloc
+		yyg->yy_buffer_stack = (struct yy_buffer_state**)router_yyrealloc
 								(yyg->yy_buffer_stack,
 								num_to_alloc * sizeof(struct yy_buffer_state*)
 								, yyscanner);
 		if ( ! yyg->yy_buffer_stack )
-			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
+			YY_FATAL_ERROR( "out of dynamic memory in router_yyensure_buffer_stack()" );
 
 		/* zero only the new slots.*/
 		memset(yyg->yy_buffer_stack + yyg->yy_buffer_stack_max, 0, grow_size * sizeof(struct yy_buffer_state*));
@@ -2836,9 +2609,9 @@ static void yyensure_buffer_stack (yyscan_t yyscanner)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * @param yyscanner The scanner object.
- * @return the newly allocated buffer state object.
+ * @return the newly allocated buffer state object. 
  */
-YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
+YY_BUFFER_STATE router_yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
     
@@ -2846,69 +2619,68 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size , yyscan_t yyscann
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return NULL;
+		return 0;
 
-	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state ) , yyscanner );
+	b = (YY_BUFFER_STATE) router_yyalloc(sizeof( struct yy_buffer_state ) ,yyscanner );
 	if ( ! b )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
+		YY_FATAL_ERROR( "out of dynamic memory in router_yy_scan_buffer()" );
 
-	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = NULL;
+	b->yy_input_file = 0;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer( b , yyscanner );
+	router_yy_switch_to_buffer(b ,yyscanner );
 
 	return b;
 }
 
-/** Setup the input buffer state to scan a string. The next call to yylex() will
+/** Setup the input buffer state to scan a string. The next call to router_yylex() will
  * scan from a @e copy of @a str.
  * @param yystr a NUL-terminated string to scan
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  * @note If you want to scan bytes that may contain NUL values, then use
- *       yy_scan_bytes() instead.
+ *       router_yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (const char * yystr , yyscan_t yyscanner)
+YY_BUFFER_STATE router_yy_scan_string (yyconst char * yystr , yyscan_t yyscanner)
 {
     
-	return yy_scan_bytes( yystr, (int) strlen(yystr) , yyscanner);
+	return router_yy_scan_bytes(yystr,strlen(yystr) ,yyscanner);
 }
 
-/** Setup the input buffer state to scan the given bytes. The next call to yylex() will
+/** Setup the input buffer state to scan the given bytes. The next call to router_yylex() will
  * scan from a @e copy of @a bytes.
- * @param yybytes the byte buffer to scan
- * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
+ * @param bytes the byte buffer to scan
+ * @param len the number of bytes in the buffer pointed to by @a bytes.
  * @param yyscanner The scanner object.
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan_t yyscanner)
+YY_BUFFER_STATE router_yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len , yyscan_t yyscanner)
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n;
-	int i;
+	yy_size_t n, i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = (yy_size_t) (_yybytes_len + 2);
-	buf = (char *) yyalloc( n , yyscanner );
+	n = _yybytes_len + 2;
+	buf = (char *) router_yyalloc(n ,yyscanner );
 	if ( ! buf )
-		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
+		YY_FATAL_ERROR( "out of dynamic memory in router_yy_scan_bytes()" );
 
 	for ( i = 0; i < _yybytes_len; ++i )
 		buf[i] = yybytes[i];
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer( buf, n , yyscanner);
+	b = router_yy_scan_buffer(buf,n ,yyscanner);
 	if ( ! b )
-		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
+		YY_FATAL_ERROR( "bad buffer in router_yy_scan_bytes()" );
 
 	/* It's okay to grow etc. this buffer, and we should throw it
 	 * away when we're done.
@@ -2922,11 +2694,9 @@ YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len , yyscan
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
+static void yy_fatal_error (yyconst char* msg , yyscan_t yyscanner)
 {
-	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	(void)yyg;
-	fprintf( stderr, "%s\n", msg );
+    	(void) fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2952,7 +2722,7 @@ static void yynoreturn yy_fatal_error (const char* msg , yyscan_t yyscanner)
 /** Get the user-defined data for this scanner.
  * @param yyscanner The scanner object.
  */
-YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
+YY_EXTRA_TYPE router_yyget_extra  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyextra;
@@ -2961,10 +2731,10 @@ YY_EXTRA_TYPE yyget_extra  (yyscan_t yyscanner)
 /** Get the current line number.
  * @param yyscanner The scanner object.
  */
-int yyget_lineno  (yyscan_t yyscanner)
+int router_yyget_lineno  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-
+    
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2974,10 +2744,10 @@ int yyget_lineno  (yyscan_t yyscanner)
 /** Get the current column number.
  * @param yyscanner The scanner object.
  */
-int yyget_column  (yyscan_t yyscanner)
+int router_yyget_column  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-
+    
         if (! YY_CURRENT_BUFFER)
             return 0;
     
@@ -2987,7 +2757,7 @@ int yyget_column  (yyscan_t yyscanner)
 /** Get the input stream.
  * @param yyscanner The scanner object.
  */
-FILE *yyget_in  (yyscan_t yyscanner)
+FILE *router_yyget_in  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyin;
@@ -2996,7 +2766,7 @@ FILE *yyget_in  (yyscan_t yyscanner)
 /** Get the output stream.
  * @param yyscanner The scanner object.
  */
-FILE *yyget_out  (yyscan_t yyscanner)
+FILE *router_yyget_out  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyout;
@@ -3005,7 +2775,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-int yyget_leng  (yyscan_t yyscanner)
+yy_size_t router_yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;
@@ -3015,7 +2785,7 @@ int yyget_leng  (yyscan_t yyscanner)
  * @param yyscanner The scanner object.
  */
 
-char *yyget_text  (yyscan_t yyscanner)
+char *router_yyget_text  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yytext;
@@ -3025,81 +2795,81 @@ char *yyget_text  (yyscan_t yyscanner)
  * @param user_defined The data to be associated with this scanner.
  * @param yyscanner The scanner object.
  */
-void yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
+void router_yyset_extra (YY_EXTRA_TYPE  user_defined , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yyextra = user_defined ;
 }
 
 /** Set the current line number.
- * @param _line_number line number
+ * @param line_number
  * @param yyscanner The scanner object.
  */
-void yyset_lineno (int  _line_number , yyscan_t yyscanner)
+void router_yyset_lineno (int  line_number , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* lineno is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yyset_lineno called with no buffer" );
+           yy_fatal_error( "router_yyset_lineno called with no buffer" , yyscanner); 
     
-    yylineno = _line_number;
+    yylineno = line_number;
 }
 
 /** Set the current column.
- * @param _column_no column number
+ * @param line_number
  * @param yyscanner The scanner object.
  */
-void yyset_column (int  _column_no , yyscan_t yyscanner)
+void router_yyset_column (int  column_no , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
         /* column is only valid if an input buffer exists. */
         if (! YY_CURRENT_BUFFER )
-           YY_FATAL_ERROR( "yyset_column called with no buffer" );
+           yy_fatal_error( "router_yyset_column called with no buffer" , yyscanner); 
     
-    yycolumn = _column_no;
+    yycolumn = column_no;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param _in_str A readable stream.
+ * @param in_str A readable stream.
  * @param yyscanner The scanner object.
- * @see yy_switch_to_buffer
+ * @see router_yy_switch_to_buffer
  */
-void yyset_in (FILE *  _in_str , yyscan_t yyscanner)
+void router_yyset_in (FILE *  in_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yyin = _in_str ;
+    yyin = in_str ;
 }
 
-void yyset_out (FILE *  _out_str , yyscan_t yyscanner)
+void router_yyset_out (FILE *  out_str , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yyout = _out_str ;
+    yyout = out_str ;
 }
 
-int yyget_debug  (yyscan_t yyscanner)
+int router_yyget_debug  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yy_flex_debug;
 }
 
-void yyset_debug (int  _bdebug , yyscan_t yyscanner)
+void router_yyset_debug (int  bdebug , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-    yy_flex_debug = _bdebug ;
+    yy_flex_debug = bdebug ;
 }
 
 /* Accessor methods for yylval and yylloc */
 
-YYSTYPE * yyget_lval  (yyscan_t yyscanner)
+YYSTYPE * router_yyget_lval  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yylval;
 }
 
-void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
+void router_yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     yylval = yylval_param;
@@ -3107,18 +2877,20 @@ void yyset_lval (YYSTYPE *  yylval_param , yyscan_t yyscanner)
 
 /* User-visible API */
 
-/* yylex_init is special because it creates the scanner itself, so it is
+/* router_yylex_init is special because it creates the scanner itself, so it is
  * the ONLY reentrant function that doesn't take the scanner as the last argument.
  * That's why we explicitly handle the declaration, instead of using our macros.
  */
-int yylex_init(yyscan_t* ptr_yy_globals)
+
+int router_yylex_init(yyscan_t* ptr_yy_globals)
+
 {
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
 
-    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), NULL );
+    *ptr_yy_globals = (yyscan_t) router_yyalloc ( sizeof( struct yyguts_t ), NULL );
 
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
@@ -3131,37 +2903,39 @@ int yylex_init(yyscan_t* ptr_yy_globals)
     return yy_init_globals ( *ptr_yy_globals );
 }
 
-/* yylex_init_extra has the same functionality as yylex_init, but follows the
+/* router_yylex_init_extra has the same functionality as router_yylex_init, but follows the
  * convention of taking the scanner as the last argument. Note however, that
  * this is a *pointer* to a scanner, as it will be allocated by this call (and
  * is the reason, too, why this function also must handle its own declaration).
- * The user defined value in the first argument will be available to yyalloc in
+ * The user defined value in the first argument will be available to router_yyalloc in
  * the yyextra field.
  */
-int yylex_init_extra( YY_EXTRA_TYPE yy_user_defined, yyscan_t* ptr_yy_globals )
+
+int router_yylex_init_extra(YY_EXTRA_TYPE yy_user_defined,yyscan_t* ptr_yy_globals )
+
 {
     struct yyguts_t dummy_yyguts;
 
-    yyset_extra (yy_user_defined, &dummy_yyguts);
+    router_yyset_extra (yy_user_defined, &dummy_yyguts);
 
     if (ptr_yy_globals == NULL){
         errno = EINVAL;
         return 1;
     }
-
-    *ptr_yy_globals = (yyscan_t) yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
-
+	
+    *ptr_yy_globals = (yyscan_t) router_yyalloc ( sizeof( struct yyguts_t ), &dummy_yyguts );
+	
     if (*ptr_yy_globals == NULL){
         errno = ENOMEM;
         return 1;
     }
-
+    
     /* By setting to 0xAA, we expose bugs in
     yy_init_globals. Leave at 0x00 for releases. */
     memset(*ptr_yy_globals,0x00,sizeof(struct yyguts_t));
-
-    yyset_extra (yy_user_defined, *ptr_yy_globals);
-
+    
+    router_yyset_extra (yy_user_defined, *ptr_yy_globals);
+    
     return yy_init_globals ( *ptr_yy_globals );
 }
 
@@ -3169,13 +2943,13 @@ static int yy_init_globals (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     /* Initialization is the same as for the non-reentrant scanner.
-     * This function is called from yylex_destroy(), so don't allocate here.
+     * This function is called from router_yylex_destroy(), so don't allocate here.
      */
 
-    yyg->yy_buffer_stack = NULL;
+    yyg->yy_buffer_stack = 0;
     yyg->yy_buffer_stack_top = 0;
     yyg->yy_buffer_stack_max = 0;
-    yyg->yy_c_buf_p = NULL;
+    yyg->yy_c_buf_p = (char *) 0;
     yyg->yy_init = 0;
     yyg->yy_start = 0;
 
@@ -3188,42 +2962,42 @@ static int yy_init_globals (yyscan_t yyscanner)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = NULL;
-    yyout = NULL;
+    yyin = (FILE *) 0;
+    yyout = (FILE *) 0;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
-     * yylex_init()
+     * router_yylex_init()
      */
     return 0;
 }
 
-/* yylex_destroy is for both reentrant and non-reentrant scanners. */
-int yylex_destroy  (yyscan_t yyscanner)
+/* router_yylex_destroy is for both reentrant and non-reentrant scanners. */
+int router_yylex_destroy  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
 
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer( YY_CURRENT_BUFFER , yyscanner );
+		router_yy_delete_buffer(YY_CURRENT_BUFFER ,yyscanner );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
-		yypop_buffer_state(yyscanner);
+		router_yypop_buffer_state(yyscanner);
 	}
 
 	/* Destroy the stack itself. */
-	yyfree(yyg->yy_buffer_stack , yyscanner);
+	router_yyfree(yyg->yy_buffer_stack ,yyscanner);
 	yyg->yy_buffer_stack = NULL;
 
     /* Destroy the start condition stack. */
-        yyfree( yyg->yy_start_stack , yyscanner );
+        router_yyfree(yyg->yy_start_stack ,yyscanner );
         yyg->yy_start_stack = NULL;
 
     /* Reset the globals. This is important in a non-reentrant scanner so the next time
-     * yylex() is called, initialization will occur. */
+     * router_yylex() is called, initialization will occur. */
     yy_init_globals( yyscanner);
 
     /* Destroy the main struct (reentrant only). */
-    yyfree ( yyscanner , yyscanner );
+    router_yyfree ( yyscanner , yyscanner );
     yyscanner = NULL;
     return 0;
 }
@@ -3233,21 +3007,18 @@ int yylex_destroy  (yyscan_t yyscanner)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, const char * s2, int n , yyscan_t yyscanner)
+static void yy_flex_strncpy (char* s1, yyconst char * s2, int n , yyscan_t yyscanner)
 {
-	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	(void)yyg;
-
-	int i;
+	register int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
+static int yy_flex_strlen (yyconst char * s , yyscan_t yyscanner)
 {
-	int n;
+	register int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -3255,18 +3026,13 @@ static int yy_flex_strlen (const char * s , yyscan_t yyscanner)
 }
 #endif
 
-void *yyalloc (yy_size_t  size , yyscan_t yyscanner)
+void *router_yyalloc (yy_size_t  size , yyscan_t yyscanner)
 {
-	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	(void)yyg;
-	return malloc(size);
+	return (void *) malloc( size );
 }
 
-void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
+void *router_yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 {
-	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	(void)yyg;
-
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -3274,18 +3040,17 @@ void *yyrealloc  (void * ptr, yy_size_t  size , yyscan_t yyscanner)
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return realloc(ptr, size);
+	return (void *) realloc( (char *) ptr, size );
 }
 
-void yyfree (void * ptr , yyscan_t yyscanner)
+void router_yyfree (void * ptr , yyscan_t yyscanner)
 {
-	struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
-	(void)yyg;
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+	free( (char *) ptr );	/* see router_yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
 #line 348 "conffile.l"
+
 
 

--- a/relay.h
+++ b/relay.h
@@ -44,7 +44,7 @@ extern char relay_hostname[];
 enum logdst { LOGOUT, LOGERR };
 
 typedef enum { CON_TCP, CON_UDP, CON_PIPE, CON_FILE, CON_UNIX } con_proto;
-typedef enum { T_LINEMODE } con_type;
+typedef enum { T_LINEMODE, T_SYSLOGMODE } con_type;
 typedef enum { W_PLAIN, W_GZIP, W_LZ4, W_SSL } con_trnsp;
 
 int relaylog(enum logdst dest, const char *fmt, ...);

--- a/router.c
+++ b/router.c
@@ -1762,7 +1762,8 @@ router_printconfig(router *rtr, FILE *f, char pmode)
 #define PPROTO \
 	server_ctype(s->server) == CON_UDP ? " proto udp" : ""
 #define PTYPE \
-	server_type(s->server) == T_LINEMODE ? "" : " type ???"
+	server_type(s->server) == T_LINEMODE ? "" : \
+	server_type(s->server) == T_SYSLOGMODE ? " syslog" : " type ???"
 #define PTRNSP \
 	server_transport(s->server) == W_PLAIN ? "" : \
 	server_transport(s->server) == W_GZIP  ? " transport gzip" : \
@@ -2551,6 +2552,25 @@ router_route_intern(
 		return 1; \
 	}
 
+#define fmtmetric(RET, POS, SRCADDR, CBUFF, NBUFF) \
+    if (server_type(RET[*POS].dest) == T_SYSLOGMODE) { \
+        time_t now; \
+        struct tm tm_now; \
+        char ts_now[17]; \
+        char *srcaddr_default = "127.0.0.1"; \
+        char *srcaddr_f = SRCADDR; \
+        \
+        time(&now); \
+        localtime_r(&now, &tm_now); \
+        strftime(ts_now, sizeof(ts_now), "%b %e %H:%M:%S", &tm_now); \
+        if (strlen(SRCADDR) == 0) { \
+            srcaddr_f = srcaddr_default; \
+        } \
+        snprintf(NBUFF, sizeof(NBUFF), "<30>%s %s crelay: %s", ts_now, srcaddr_f, CBUFF); \
+        RET[(*POS)++].metric = strdup(NBUFF); \
+    } else { \
+        RET[(*POS)++].metric = strdup(CBUFF); \
+    }
 
 	for (w = r; w != NULL; w = w->next) {
 		if (w->dests->cl->type == GROUP) {
@@ -2611,7 +2631,7 @@ router_route_intern(
 						{
 							failif(retsize, *curlen + 1);
 							ret[*curlen].dest = s->server;
-							ret[(*curlen)++].metric = strdup(metric);
+							fmtmetric(ret, curlen, srcaddr, metric, newmetric);
 						}
 						wassent = 1;
 					}	break;
@@ -2627,11 +2647,12 @@ router_route_intern(
 						 * (MAX_INT % c) can be considered neglicible given
 						 * the number of occurances of c in the range of
 						 * MAX_INT, therefore we stick with a simple mod. */
+						server *ds;
 						hash %= d->cl->members.anyof->count;
 						failif(retsize, *curlen + 1);
 						ret[*curlen].dest =
-							d->cl->members.anyof->servers[hash];
-						ret[(*curlen)++].metric = strdup(metric);
+						    d->cl->members.anyof->servers[hash];
+						fmtmetric(ret, curlen, srcaddr, metric, newmetric);
 						wassent = 1;
 					}	break;
 					case FAILOVER: {
@@ -2651,7 +2672,8 @@ router_route_intern(
 							/* all failed, take first server */
 							ret[*curlen].dest =
 								d->cl->members.anyof->servers[0];
-						ret[(*curlen)++].metric = strdup(metric);
+
+						fmtmetric(ret, curlen, srcaddr, metric, newmetric);
 						wassent = 1;
 					}	break;
 					case CARBON_CH:
@@ -2682,7 +2704,7 @@ router_route_intern(
 								w->masq ? newmetric : metric,
 								w->masq ? newfirstspace : firstspace);
 						for (i = 0; i < d->cl->members.ch->repl_factor; i++)
-							ret[(*curlen)++].metric = strdup(metric);
+							fmtmetric(ret, curlen, srcaddr, metric, newmetric);
 						wassent = 1;
 					}	break;
 					case AGGREGATION: {

--- a/router.c
+++ b/router.c
@@ -2647,7 +2647,6 @@ router_route_intern(
 						 * (MAX_INT % c) can be considered neglicible given
 						 * the number of occurances of c in the range of
 						 * MAX_INT, therefore we stick with a simple mod. */
-						server *ds;
 						hash %= d->cl->members.anyof->count;
 						failif(retsize, *curlen + 1);
 						ret[*curlen].dest =


### PR DESCRIPTION
PoC proposal.

While it's quite handy to have `file ip` cluster type, still, it's more for debugging purposes rather then permanent solution.
When dealing with legacy systems, it's quite handy to be able to analyse sources of incoming metrics. Syslog format widely supported and quite easy to re-route and parse (Logstash for a example).

Rather than make new cluster type and dealing with complexity of yacc/bison stuff, i'd suggest to utilise either `server->type` or `server->transport` for dealing with syslog envelope (in this PoC, I using connection type: `server->type`.

Sample configuration file:
```
cluster test
    forward
        127.0.0.1:2020 proto udp type syslog
        127.0.0.1:2021 proto udp
    ;


match *
    send to test
    ;
```

Sample output for syslog receiver:
`<30>Apr 11 13:25:30 127.0.0.1 crelay: hello.world 1 123456789`

Implementation details:
* Syslog facility is hardcoded to be `3 (system daemons)`
* Syslog severity is hardcoded to be `6 (INFO)`
* Hostname is set to `metric source address`
* Application name is hardcoded to be `crelay`.

I'd also noticed that in case of udp receiver, source address is empty, which is result of `getpeername` call on udp socket (which is obviously empty, due the nature of udp protocol).

Please advice, can such solution to be adopted and accepted into mainline? I'd made a separate commit without autogenerated changes to demonstrate proposed approach: https://github.com/arkady-emelyanov/carbon-c-relay/commit/57fea4db44d251ca17c63c9bbdb18ab6cff08963

Thanks.