### PR TITLE
Use SOURCE_DATE_EPOCH if set to make the project build reproducibly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,11 @@ AUTOMAKE_OPTIONS = foreign
 
 CFLAGS ?= -O2 -Wall -Wshadow -pipe
 
-GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always 2>/dev/null || date +%F)
+GIT_VERSION := $(shell \
+	date -u -d "@${SOURCE_DATE_EPOCH}" "+%F" 2>/dev/null || \
+	date -u -r "${SOURCE_DATE_EPOCH}" "+%F" 2>/dev/null || \
+	git describe --abbrev=6 --dirty --always 2>/dev/null || \
+	date +%F)
 GVCFLAGS = -DGIT_VERSION=\"$(GIT_VERSION)\"
 
 override CFLAGS += $(GVCFLAGS) -pthread


### PR DESCRIPTION
While working on the [debian reproducible builds project](https://wiki.debian.org/ReproducibleBuilds), we noticed that carbon-c-relay could not be built reproducibly.

This PR changes the build system to first attempt to use the `SOURCE_DATE_EPOCH` envvar (https://reproducible-builds.org/specs/source-date-epoch/) to determine build date, then falls back to the git commit date, then the current date.