### PR TITLE
Standardize on "unsigned short" for server ports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ### New Features
 
+* **router** now emits the bad string if an invalid port was given
+
 ### Bugfixes
 
 * [Issue #346](https://github.com/grobian/carbon-c-relay/issues/346)

--- a/conffile.h
+++ b/conffile.h
@@ -106,16 +106,16 @@ typedef struct _route {
 } route;
 
 void router_yyerror(void *locp, void *, router *r, allocator *ra, allocator *pa, const char *msg);
-char *router_validate_address(router *rtr, char **retip, int *retport, void **retsaddr, void **rethint, char *ip, con_proto proto);
+char *router_validate_address(router *rtr, char **retip, unsigned short *retport, void **retsaddr, void **rethint, char *ip, con_proto proto);
 char *router_validate_path(router *rtr, char *path);
 char *router_validate_expression(router *rtr, route **retr, char *pat);
 char *router_validate_cluster(router *rtr, cluster **retcl, char *cluster);
-char *router_add_server(router *ret, char *ip, int port, char *inst, con_type type, con_trnsp transport, con_proto proto, struct addrinfo *saddrs, struct addrinfo *hint, char useall, cluster *cl);
+char *router_add_server(router *ret, char *ip, unsigned short port, char *inst, con_type type, con_trnsp transport, con_proto proto, struct addrinfo *saddrs, struct addrinfo *hint, char useall, cluster *cl);
 char *router_add_cluster(router *r, cluster *cl);
 char *router_add_route(router *r, route *rte);
 char *router_add_aggregator(router *rtr, aggregator *a);
 char *router_add_stubroute(router *rtr, enum clusttype type, cluster *w, destinations *dw);
-char *router_add_listener(router *rtr, con_type ltype, con_trnsp trnsp, char *pemcert, con_proto ctype, char *ip, int port, struct addrinfo *saddrs);
+char *router_add_listener(router *rtr, con_type ltype, con_trnsp trnsp, char *pemcert, con_proto ctype, char *ip, unsigned short port, struct addrinfo *saddrs);
 char *router_set_statistics(router *rtr, destinations *dsts);
 char *router_set_collectorvals(router *rtr, int val, char *prefix, col_mode m);
 

--- a/conffile.tab.c
+++ b/conffile.tab.c
@@ -134,7 +134,7 @@ struct _clust {
 };
 struct _clhost {
 	char *ip;
-	int port;
+	unsigned short port;
 	char *inst;
 	int proto;
 	con_type type;
@@ -162,7 +162,7 @@ struct _lsnr {
 struct _rcptr {
 	con_proto ctype;
 	char *ip;
-	int port;
+	unsigned short port;
 	void *saddr;
 	struct _rcptr *next;
 };

--- a/conffile.tab.h
+++ b/conffile.tab.h
@@ -60,7 +60,7 @@ struct _clust {
 };
 struct _clhost {
 	char *ip;
-	int port;
+	unsigned short port;
 	char *inst;
 	int proto;
 	con_type type;
@@ -88,7 +88,7 @@ struct _lsnr {
 struct _rcptr {
 	con_proto ctype;
 	char *ip;
-	int port;
+	unsigned short port;
 	void *saddr;
 	struct _rcptr *next;
 };

--- a/conffile.y
+++ b/conffile.y
@@ -15,7 +15,7 @@ struct _clust {
 };
 struct _clhost {
 	char *ip;
-	int port;
+	unsigned short port;
 	char *inst;
 	int proto;
 	con_type type;
@@ -43,7 +43,7 @@ struct _lsnr {
 struct _rcptr {
 	con_proto ctype;
 	char *ip;
-	int port;
+	unsigned short port;
 	void *saddr;
 	struct _rcptr *next;
 };

--- a/router.h
+++ b/router.h
@@ -55,7 +55,7 @@ typedef struct _router_listener {
 	con_trnsp transport;
 	con_proto ctype;
 	char *ip;
-	int port;
+	unsigned short port;
 	int *socks;
 #ifdef HAVE_SSL
 	SSL_CTX *ctx;


### PR DESCRIPTION
The "server.h" file contains the prototype for the "server_new"
function. This function expects an "unsigned short" for port.
This patch makes the code consistently use "unsigned short",
rather than a mix of "unsigned short" and "int" types.

Even better, might be to use "uint16_t", however first it should
be demonstrated that this can be done without creating platform
and toolchain compatibility headaches.

See also: https://tools.ietf.org/html/rfc6335#section-6
And:
$ grep typedef -r /usr/include/netinet | grep port
/usr/include/netinet/in.h:typedef uint16_t in_port_t;

I wasn't sure what to put in the ChangeLog.md, please advise, and I can amend the commit