### PR TITLE
Upgrade Alpine version + use multistage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,19 @@
-FROM alpine:3.6
+FROM alpine:3.10 AS builder
+
+ADD . /opt/carbon-c-relay-build
+WORKDIR /opt/carbon-c-relay-build
+
+RUN \
+  apk add --no-cache git bc build-base curl automake autoconf && \
+  ./configure && make
+
+FROM alpine:3.10
 
 MAINTAINER Fabian Groffen
 
-RUN mkdir -p /opt/carbon-c-relay-build
+RUN mkdir -p /etc/carbon-c-relay
 
-RUN mkdir /etc/carbon-c-relay
-
-COPY . /opt/carbon-c-relay-build
-
-RUN \
-  apk --no-cache update && \
-  apk --no-cache upgrade && \
-  apk --no-cache add git bc build-base curl && \
-  cd /opt/carbon-c-relay-build && \
-  ./configure; make && \
-  cp relay /usr/bin/carbon-c-relay && \
-  apk del --purge git bc build-base ca-certificates curl && \
-  rm -rf /opt/* /tmp/* /var/cache/apk/* /opt/carbon-c-relay-build
+COPY --from=builder /opt/carbon-c-relay-build/relay /usr/bin/carbon-c-relay
 
 EXPOSE 2003
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ FROM alpine:3.10
 
 MAINTAINER Fabian Groffen
 
-RUN mkdir -p /etc/carbon-c-relay
+RUN mkdir /etc/carbon-c-relay
 
 COPY --from=builder /opt/carbon-c-relay-build/relay /usr/bin/carbon-c-relay
 
 EXPOSE 2003
 
-ENTRYPOINT ["carbon-c-relay", "-f", "/etc/carbon-c-relay/carbon-c-relay.conf"]
+ENTRYPOINT ["/usr/bin/carbon-c-relay", "-f", "/etc/carbon-c-relay/carbon-c-relay.conf"]
 


### PR DESCRIPTION
This is PR is to use a more recent version of Alpine for the Docker container + use a multistage build instead of cleaning up the image after the build.