### PR TITLE
router: fix snprintf buffer length

### DIFF
--- a/router.c
+++ b/router.c
@@ -2194,7 +2194,7 @@ router_printdiffs(router *old, router *new, FILE *out)
 	char *tmp = getenv("TMPDIR");
 	char patho[512];
 	char pathn[512];
-	char buf[1024];
+	char buf[1033];
 	size_t len;
 	int ret;
 	mode_t mask;

--- a/router.c
+++ b/router.c
@@ -3122,8 +3122,8 @@ router_test_intern(char *metric, char *firstspace, route *routes)
 						if (mode & MODE_DEBUG || d->next == NULL) {
 							stublen = 0;
 						} else {
-							char x;
-							stublen = snprintf(&x, 1,
+							char x[32];
+							stublen = snprintf(x, 32,
 									STUB_AGGR "%p__",
 									d->cl->members.aggregation);
 						}


### PR DESCRIPTION
router.c: In function ‘router_printdiffs’:
router.c:2245:29: error: ‘%s’ directive output may be truncated writing up to 511 bytes into a region of size between 504 and 1015 [-Werror=format-truncation=]
  snprintf(buf, sizeof(buf), "diff -u %s %s", patho, pathn);
                             ^~~~~~~~~~~~~~~         ~~~~~
router.c:2245:2: note: ‘snprintf’ output between 10 and 1032 by