### PR TITLE
Fix #400 Tagged metrics dropped during aggregation

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -933,7 +933,7 @@ dispatch_connection(connection *conn, dispatcher *self, struct timeval start)
 						router_route(self->rtr,
 							conn->dests, &conn->destlen, CONN_DESTS_SIZE,
 							conn->srcaddr,
-							conn->metric, firstspace, self->id - 1));
+							conn->metric, strchr(firstspace, ' '), self->id - 1));
 				tracef("dispatcher %d, connfd %d, destinations %zd\n",
 						self->id, conn->sock, conn->destlen);
 


### PR DESCRIPTION
Removing garbage from `firstspace` variable with `strchr()` just before sending it to router seem to me as a sufficient solution. All other checks and sanitizes was performed earlier.