### PR TITLE
receptor: Fix wrong function type for bindlisten*()

### DIFF
--- a/receptor.c
+++ b/receptor.c
@@ -36,7 +36,7 @@
 #endif
 
 
-static char
+static int
 bindlistenip(listener *lsnr, unsigned int backlog)
 {
 	int sock;
@@ -165,7 +165,7 @@ bindlistenip(listener *lsnr, unsigned int backlog)
 	return 0;
 }
 
-static char
+static int
 bindlistenunix(listener *lsnr, unsigned int backlog)
 {
 	struct sockaddr_un srvr;
@@ -210,7 +210,7 @@ bindlistenunix(listener *lsnr, unsigned int backlog)
  * Open up sockets associated with listener.  Returns 0 when opening up
  * the listener succeeded, 1 otherwise.
  */
-char
+int
 bindlisten(listener *lsnr, unsigned int backlog)
 {
 	switch (lsnr->ctype) {


### PR DESCRIPTION
```c
receptor.h:23:5: warning: type of 'bindlisten' does not match original declaration [-Wlto-type-mismatch]
   23 | int bindlisten(listener *lsnr, unsigned int backlog);
      |     ^
receptor.c:214:1: note: return value type mismatch
  214 | bindlisten(listener *lsnr, unsigned int backlog)
      | ^
receptor.c:214:1: note: type 'char' should match type 'int'
receptor.c:214:1: note: 'bindlisten' was previously declared here
```

Signed-off-by: Igor Raits <igor.raits@gmail.com>