### PR TITLE
Do not feed LZ4F_decompress() with the already consumed data.

### DIFF
--- a/dispatcher.c
+++ b/dispatcher.c
@@ -409,11 +409,9 @@ lzreadbuf(z_strm *strm, void *buf, size_t sze, int rval, int err)
 		return -1;
 	}
 
-	/* if we decompressed something, update our ibuf */
+	strm->hdl.lz4.iloc += srcsize;
 
-	if (destsize > 0) {
-		strm->hdl.lz4.iloc += srcsize;
-	} else if (destsize == 0) {
+	if (destsize == 0) {
 		tracef("No LZ4 data was produced\n");
 		errno = err ? err : EAGAIN;
 		return -1;


### PR DESCRIPTION
Fix for the #440

Update strm->hdl.lz4.iloc even if LZ4F_decompress() writes nothing to the dstBuffer but consumes from the srcBuffer. 
Otherwise, the next run will fail with -16 ERROR_decompressionFailed because srcBuffer contains data consumed in the previous run.