### PR TITLE
load whole ssl certificate chain when loading certificates

### DIFF
--- a/receptor.c
+++ b/receptor.c
@@ -135,8 +135,8 @@ ssllisten(listener *lsnr)
 #endif
 
 	/* load certificates */
-	if (SSL_CTX_use_certificate_file(
-				lsnr->ctx, lsnr->pemcert, SSL_FILETYPE_PEM) <= 0)
+	if (SSL_CTX_use_certificate_chain_file(
+				lsnr->ctx, lsnr->pemcert) <= 0)
 	{
 		char *err = ERR_error_string(ERR_get_error(), NULL);
 		SSL_CTX_free(lsnr->ctx);

--- a/server.c
+++ b/server.c
@@ -939,9 +939,7 @@ server_queuereader(void *d)
 					int ret;
 
 					/* issue #444 */
-					ret = SSL_use_certificate_file(sstrm->hdl.ssl,
-												   self->mtlspemcert,
-												   SSL_FILETYPE_PEM);
+					ret = SSL_use_certificate_chain_file(sstrm->hdl.ssl, self->mtlspemcert);
 					if (ret == 1) {
 						ret = SSL_use_PrivateKey_file(sstrm->hdl.ssl,
 													  self->mtlspemkey,


### PR DESCRIPTION
This is needed for proper supply of whole certificate chain. Otherwise intermediate certificates from pem file are not loaded and served which causes SSL validation errors.

Even recommended by openssl documetation:
```
SSL_CTX_use_certificate_chain_file() should be used instead of the SSL_CTX_use_certificate_file() function in order to allow the use of complete certificate chains even when no trusted CA storage is used or when the CA issuing the certificate shall not be added to the trusted CA storage.
```